### PR TITLE
refactor(scripts): support editing-trace.js format in download-fixtures

### DIFF
--- a/scripts/download-fixtures.ts
+++ b/scripts/download-fixtures.ts
@@ -7,10 +7,76 @@ const EDITING_TRACE_PATH = join(FIXTURES_DIR, "editing-trace.json");
 
 // Kleppmann's editing trace - 260K operations from real editing sessions
 // Source: https://github.com/automerge/automerge-perf
+// The file is a JavaScript module with `const edits = [...]` and `const finalText = "..."` format
 const EDITING_TRACE_URL =
-  "https://raw.githubusercontent.com/automerge/automerge-perf/master/edit-by-index/sequential_traces/editing-trace.json";
+  "https://raw.githubusercontent.com/automerge/automerge-perf/master/edit-by-index/editing-trace.js";
 
-async function downloadFile(url: string, dest: string): Promise<void> {
+interface EditOperation {
+  position: number;
+  deleteCount: number;
+  insertText: string;
+}
+
+interface EditingTrace {
+  operations: EditOperation[];
+  finalText: string;
+}
+
+// Parse the JavaScript file which has format:
+// const edits = [[pos, del, text], ...]  (text may be omitted for delete-only)
+// const finalText = "..."
+function parseEditingTraceJs(content: string): EditingTrace {
+  // Use Function constructor to safely evaluate the JS and extract the values
+  // The file exports: const edits = [...]; const finalText = "..."; module.exports = { edits, finalText }
+  // We can extract by creating a mock module object and evaluating
+
+  // Extract edits array - match from "const edits = [" to the next "const" or "if"
+  const editsMatch = content.match(/const\s+edits\s*=\s*\[([\s\S]*?)\];/);
+  if (!editsMatch) {
+    throw new Error("Could not parse editing-trace.js: expected 'const edits = [...]' format");
+  }
+
+  // Extract finalText
+  const finalTextMatch = content.match(/const\s+finalText\s*=\s*"((?:[^"\\]|\\.)*)"/);
+  if (!finalTextMatch) {
+    throw new Error(
+      "Could not parse editing-trace.js: expected 'const finalText = \"...\"' format",
+    );
+  }
+
+  // Parse edits array manually - each line is [pos, del] or [pos, del, "text"]
+  const editsContent = editsMatch[1];
+  if (editsContent === undefined) {
+    throw new Error("Could not extract edits content from editing-trace.js");
+  }
+  const operations: EditOperation[] = [];
+
+  // Match each array entry: [num, num] or [num, num, "string"]
+  const entryRegex = /\[(\d+),\s*(\d+)(?:,\s*"((?:[^"\\]|\\.)*)")?\]/g;
+  let match: RegExpExecArray | null = entryRegex.exec(editsContent);
+  while (match !== null) {
+    const posStr = match[1];
+    const delStr = match[2];
+    if (posStr !== undefined && delStr !== undefined) {
+      const position = Number.parseInt(posStr, 10);
+      const deleteCount = Number.parseInt(delStr, 10);
+      const insertText = match[3] !== undefined ? JSON.parse(`"${match[3]}"`) : "";
+      operations.push({ position, deleteCount, insertText });
+    }
+    match = entryRegex.exec(editsContent);
+  }
+
+  // Unescape the finalText
+  const finalTextRaw = finalTextMatch[1];
+  if (finalTextRaw === undefined) {
+    throw new Error("Could not extract finalText from editing-trace.js");
+  }
+  const finalText = JSON.parse(`"${finalTextRaw}"`) as string;
+
+  return { operations, finalText };
+}
+
+async function downloadAndConvert(url: string, dest: string): Promise<void> {
   console.log(`Downloading ${url}...`);
 
   const response = await fetch(url);
@@ -18,14 +84,18 @@ async function downloadFile(url: string, dest: string): Promise<void> {
     throw new Error(`Failed to download: ${response.status} ${response.statusText}`);
   }
 
-  const content = await response.text();
+  const jsContent = await response.text();
+  console.log("Parsing and converting to JSON...");
+
+  const trace = parseEditingTraceJs(jsContent);
+  console.log(`Parsed ${trace.operations.length} operations`);
 
   const dir = dirname(dest);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
 
-  await writeFile(dest, content);
+  await writeFile(dest, JSON.stringify(trace));
   console.log(`Saved to ${dest}`);
 }
 
@@ -36,7 +106,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  await downloadFile(EDITING_TRACE_URL, EDITING_TRACE_PATH);
+  await downloadAndConvert(EDITING_TRACE_URL, EDITING_TRACE_PATH);
   console.log("Done!");
 }
 


### PR DESCRIPTION
Updated the download-fixtures script to parse JavaScript files instead of JSON, enabling compatibility with the Automerge perf repository's actual file format.

**Changes:**

- Added `parseEditingTraceJs` function that uses regex matching to extract the `const edits` array and `const finalText` variable from JavaScript files
- Converts extracted data into structured `EditOperation` objects and saves as JSON
- Renamed `downloadFile` to `downloadAndConvert` to better reflect its dual responsibility of downloading and parsing files
- The script now successfully handles the editing-trace.js format used in the Automerge perf test repository

This change enables the fixture download script to work with the actual repository structure without requiring intermediate JSON conversion.

> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/iamnbutler/crdt/01KMERPG4RE5SR56Y6SEN0AQD9)