### PR TITLE
fix(text): resolve Order Independence failures (#27)

### DIFF
--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -1016,11 +1016,16 @@ export class TextBuffer {
     observeVersion(this._version, op.id.replicaId, op.id.counter);
     mergeVersionVectors(this._version, op.version);
 
-    const frags = this.fragmentsArray();
-    const newFrags: Fragment[] = [];
+    // Use a work list approach: when a fragment is split, the resulting parts
+    // may still overlap with other delete ranges and need re-processing.
+    const workList = [...this.fragmentsArray()];
+    const resultFrags: Fragment[] = [];
 
-    for (const frag of frags) {
-      let handled = false;
+    while (workList.length > 0) {
+      const frag = workList.shift();
+      if (frag === undefined) break; // Should never happen, but satisfies lint
+      let wasProcessed = false;
+
       for (const range of op.ranges) {
         if (!operationIdsEqual(frag.insertionId, range.insertionId)) {
           continue;
@@ -1038,24 +1043,25 @@ export class TextBuffer {
         }
 
         if (fragStart >= rangeStart && fragEnd <= rangeEnd) {
-          // Fragment is entirely within the delete range
-          newFrags.push(deleteFragment(frag, op.id));
-          handled = true;
+          // Fragment is entirely within the delete range - done with this fragment
+          resultFrags.push(deleteFragment(frag, op.id));
+          wasProcessed = true;
           break;
         }
 
         if (fragStart < rangeStart && fragEnd > rangeEnd) {
           // Delete range is entirely within this fragment — split into 3 parts
+          // The "after" part might still overlap with other ranges, so re-check it.
           const deleteLocalStart = rangeStart - fragStart;
           const deleteLocalEnd = rangeEnd - fragStart;
 
           const [beforePart, rest] = splitFragment(frag, deleteLocalStart);
           const [deletedPart, afterPart] = splitFragment(rest, deleteLocalEnd - deleteLocalStart);
 
-          newFrags.push(beforePart);
-          newFrags.push(deleteFragment(deletedPart, op.id));
-          newFrags.push(afterPart);
-          handled = true;
+          resultFrags.push(beforePart);
+          resultFrags.push(deleteFragment(deletedPart, op.id));
+          workList.unshift(afterPart); // Re-check against remaining ranges
+          wasProcessed = true;
           break;
         }
 
@@ -1064,27 +1070,38 @@ export class TextBuffer {
           const splitPoint = rangeStart - fragStart;
           const [keepPart, deletedPart] = splitFragment(frag, splitPoint);
 
-          newFrags.push(keepPart);
-          newFrags.push(deleteFragment(deletedPart, op.id));
-          handled = true;
+          resultFrags.push(keepPart);
+          resultFrags.push(deleteFragment(deletedPart, op.id));
+          wasProcessed = true;
           break;
         }
 
         // Delete range overlaps the start of this fragment (fragEnd > rangeEnd)
+        // The "keep" part might still overlap with other ranges, so re-check it.
         const splitPoint = rangeEnd - fragStart;
         const [deletedPart, keepPart] = splitFragment(frag, splitPoint);
 
-        newFrags.push(deleteFragment(deletedPart, op.id));
-        newFrags.push(keepPart);
-        handled = true;
+        resultFrags.push(deleteFragment(deletedPart, op.id));
+        workList.unshift(keepPart); // Re-check against remaining ranges
+        wasProcessed = true;
         break;
       }
-      if (!handled) {
-        newFrags.push(frag);
+      if (!wasProcessed) {
+        resultFrags.push(frag);
       }
     }
 
-    this.fragments = SumTree.fromItems(newFrags, fragmentSummaryOps);
+    // Sort by (locator, insertionId, insertionOffset) to maintain canonical order
+    // after splits. This matches the sorting in applyRemoteInsertDirect.
+    resultFrags.sort((a, b) => {
+      const locCmp = compareLocators(a.locator, b.locator);
+      if (locCmp !== 0) return locCmp;
+      const idCmp = compareOperationIds(a.insertionId, b.insertionId);
+      if (idCmp !== 0) return idCmp;
+      return a.insertionOffset - b.insertionOffset;
+    });
+
+    this.fragments = SumTree.fromItems(resultFrags, fragmentSummaryOps);
   }
 
   private applyRemoteUndo(op: UndoOperation): void {


### PR DESCRIPTION
## Summary

- Fixes all 26 remaining Order Independence property test failures
- Implements work list approach in `applyRemoteDelete` to re-check split fragments against multiple delete ranges
- Adds canonical sorting after delete operations to ensure consistent fragment order across replicas

## Problem

When a delete operation contains multiple ranges that overlap with the same fragment, the previous implementation would:
1. Process the first matching range and split the fragment
2. Break out of the loop, skipping checks against remaining ranges
3. Leave split fragments potentially overlapping with unprocessed ranges

This caused Order Independence failures where replicas applying the same operations in different orders would produce different text.

## Solution

1. **Work list approach**: Changed from a simple for-loop to a work list that allows fragments to be re-processed after splits
2. **Re-checking split fragments**: When splitting creates "afterPart" or "keepPart" fragments, they're added back to the front of the work list to be checked against remaining delete ranges
3. **Canonical sorting**: Added sorting by (locator, insertionId, insertionOffset) after processing to maintain consistent order

## Test Results

| Test Suite | Before | After |
|------------|--------|-------|
| Order Independence | 474/500 pass | **500/500 pass** |
| Undo Correctness | 1000/1000 pass | 1000/1000 pass |
| Basic text-buffer tests | 120/120 pass | 120/120 pass |

## Test plan

- [x] All Order Independence property tests pass (500/500)
- [x] All Undo Correctness property tests pass (1000/1000)
- [x] All basic text-buffer tests pass (120/120)
- [x] Commutativity, Idempotency, Anchor Stability tests unaffected

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)