### PR TITLE
perf(text): O(log n) insert via SumTree incremental operations

### DIFF
--- a/src/sum-tree/index.test.ts
+++ b/src/sum-tree/index.test.ts
@@ -522,4 +522,137 @@ describe("SumTree", () => {
       }
     }
   });
+
+  describe("seekIndex and seekIndexAndPosition", () => {
+    it("returns index at dimension position", () => {
+      const items = Array.from({ length: 10 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps);
+
+      // Count dimension: each item contributes 1
+      expect(tree.seekIndex(countDimension, 0, "right")).toBe(0);
+      expect(tree.seekIndex(countDimension, 5, "right")).toBe(5);
+      expect(tree.seekIndex(countDimension, 10, "right")).toBe(10);
+    });
+
+    it("returns index and position", () => {
+      const items = Array.from({ length: 10 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps);
+
+      const result = tree.seekIndexAndPosition(countDimension, 5, "right");
+      expect(result.index).toBe(5);
+      expect(result.position).toBe(5); // accumulated count before item 5
+    });
+
+    it("handles empty tree", () => {
+      const tree = new SumTree<CountItem, CountSummary>(countSummaryOps);
+
+      expect(tree.seekIndex(countDimension, 0, "right")).toBe(0);
+      expect(tree.seekIndex(countDimension, 5, "right")).toBe(0);
+    });
+
+    it("works with text dimensions", () => {
+      const chunks = [new TextChunk("abc"), new TextChunk("def"), new TextChunk("ghi")];
+      const tree = SumTree.fromItems(chunks, textSummaryOps);
+
+      // UTF-16 dimension
+      expect(tree.seekIndex(utf16Dimension, 0, "right")).toBe(0);
+      expect(tree.seekIndex(utf16Dimension, 3, "right")).toBe(1); // at start of "def"
+      expect(tree.seekIndex(utf16Dimension, 6, "right")).toBe(2); // at start of "ghi"
+      expect(tree.seekIndex(utf16Dimension, 9, "right")).toBe(3); // past end
+    });
+  });
+
+  describe("replaceAt", () => {
+    it("replaces item at index", () => {
+      let tree = SumTree.fromItems(
+        [new CountItem(1), new CountItem(2), new CountItem(3)],
+        countSummaryOps,
+      );
+
+      tree = tree.replaceAt(1, new CountItem(99));
+
+      expect(tree.get(0)?.value).toBe(1);
+      expect(tree.get(1)?.value).toBe(99);
+      expect(tree.get(2)?.value).toBe(3);
+      expect(tree.length()).toBe(3);
+    });
+
+    it("does not mutate original", () => {
+      const original = SumTree.fromItems(
+        [new CountItem(1), new CountItem(2), new CountItem(3)],
+        countSummaryOps,
+      );
+
+      const modified = original.replaceAt(1, new CountItem(99));
+
+      expect(original.get(1)?.value).toBe(2);
+      expect(modified.get(1)?.value).toBe(99);
+    });
+
+    it("updates summary correctly", () => {
+      let tree = SumTree.fromItems(
+        [new CountItem(1), new CountItem(2), new CountItem(3)],
+        countSummaryOps,
+      );
+
+      tree = tree.replaceAt(1, new CountItem(99));
+
+      expect(tree.summary().count).toBe(3);
+    });
+  });
+
+  describe("spliceAt", () => {
+    it("replaces one item with two", () => {
+      let tree = SumTree.fromItems(
+        [new CountItem(1), new CountItem(2), new CountItem(3)],
+        countSummaryOps,
+      );
+
+      tree = tree.spliceAt(1, 1, new CountItem(20), new CountItem(21));
+
+      expect(tree.length()).toBe(4);
+      expect(tree.get(0)?.value).toBe(1);
+      expect(tree.get(1)?.value).toBe(20);
+      expect(tree.get(2)?.value).toBe(21);
+      expect(tree.get(3)?.value).toBe(3);
+    });
+
+    it("replaces two items with one", () => {
+      let tree = SumTree.fromItems(
+        [new CountItem(1), new CountItem(2), new CountItem(3), new CountItem(4)],
+        countSummaryOps,
+      );
+
+      tree = tree.spliceAt(1, 2, new CountItem(99));
+
+      expect(tree.length()).toBe(3);
+      expect(tree.get(0)?.value).toBe(1);
+      expect(tree.get(1)?.value).toBe(99);
+      expect(tree.get(2)?.value).toBe(4);
+    });
+
+    it("inserts without deleting", () => {
+      let tree = SumTree.fromItems([new CountItem(1), new CountItem(3)], countSummaryOps);
+
+      tree = tree.spliceAt(1, 0, new CountItem(2));
+
+      expect(tree.length()).toBe(3);
+      expect(tree.get(0)?.value).toBe(1);
+      expect(tree.get(1)?.value).toBe(2);
+      expect(tree.get(2)?.value).toBe(3);
+    });
+
+    it("deletes without inserting", () => {
+      let tree = SumTree.fromItems(
+        [new CountItem(1), new CountItem(2), new CountItem(3)],
+        countSummaryOps,
+      );
+
+      tree = tree.spliceAt(1, 1);
+
+      expect(tree.length()).toBe(2);
+      expect(tree.get(0)?.value).toBe(1);
+      expect(tree.get(1)?.value).toBe(3);
+    });
+  });
 });

--- a/src/sum-tree/index.ts
+++ b/src/sum-tree/index.ts
@@ -579,6 +579,160 @@ export class SumTree<T extends Summarizable<S>, S> {
   }
 
   /**
+   * Seek to a target position in a dimension and return both the item index and accumulated position.
+   * This allows finding the array-style index at a dimension position for use with insertAt/removeAt.
+   * Returns { index, position } where:
+   * - index: the index of the item at the target position, or total count if past end
+   * - position: the accumulated dimension value BEFORE that index (for computing local offset)
+   */
+  seekIndexAndPosition<D>(
+    dimension: Dimension<S, D>,
+    target: D,
+    bias: SeekBias = "right",
+  ): { index: number; position: D } {
+    if (this.isEmpty()) {
+      return { index: 0, position: dimension.zero() };
+    }
+
+    let index = 0;
+    let current = this._root;
+    let pos = dimension.zero();
+
+    while (true) {
+      if (this.arena.isLeaf(current)) {
+        // Scan items in the leaf
+        const data = this.arena.getItem(current);
+        const items = data?.items ?? [];
+        const count = items.length;
+
+        for (let i = 0; i < count; i++) {
+          const item = items[i];
+          if (item === undefined) continue;
+
+          const itemSummary = item.summary();
+          const itemMeasure = dimension.measure(itemSummary);
+          const nextPos = dimension.add(pos, itemMeasure);
+          const cmp = dimension.compare(nextPos, target);
+
+          if (cmp > 0 || (cmp === 0 && bias === "left")) {
+            return { index, position: pos };
+          }
+
+          pos = nextPos;
+          index++;
+        }
+        return { index, position: pos };
+      }
+
+      // Internal node: find the right child
+      const children = this.arena.getChildren(current);
+      let found = false;
+
+      for (let i = 0; i < children.length; i++) {
+        const childId = children[i];
+        if (childId === undefined) continue;
+
+        const childSummary = this.summaries.get(childId);
+        if (childSummary === undefined) continue;
+
+        const childMeasure = dimension.measure(childSummary);
+        const nextPos = dimension.add(pos, childMeasure);
+        const cmp = dimension.compare(nextPos, target);
+
+        if (cmp > 0 || (cmp === 0 && bias === "left")) {
+          // Target is in this child
+          current = childId;
+          found = true;
+          break;
+        }
+
+        // Skip this child
+        pos = nextPos;
+        index += this.countItems(childId);
+      }
+
+      if (!found) {
+        // Target is past all children
+        return { index, position: pos };
+      }
+    }
+  }
+
+  /**
+   * Seek to a target position in a dimension and return the item index.
+   * This allows finding the array-style index at a dimension position for use with insertAt/removeAt.
+   * Returns the index of the item at the target position, or the total count if target is past the end.
+   */
+  seekIndex<D>(dimension: Dimension<S, D>, target: D, bias: SeekBias = "right"): number {
+    if (this.isEmpty()) {
+      return 0;
+    }
+
+    let index = 0;
+    let current = this._root;
+    let pos = dimension.zero();
+
+    while (true) {
+      if (this.arena.isLeaf(current)) {
+        // Scan items in the leaf
+        const data = this.arena.getItem(current);
+        const items = data?.items ?? [];
+        const count = items.length;
+
+        for (let i = 0; i < count; i++) {
+          const item = items[i];
+          if (item === undefined) continue;
+
+          const itemSummary = item.summary();
+          const itemMeasure = dimension.measure(itemSummary);
+          const nextPos = dimension.add(pos, itemMeasure);
+          const cmp = dimension.compare(nextPos, target);
+
+          if (cmp > 0 || (cmp === 0 && bias === "left")) {
+            return index;
+          }
+
+          pos = nextPos;
+          index++;
+        }
+        return index;
+      }
+
+      // Internal node: find the right child
+      const children = this.arena.getChildren(current);
+      let found = false;
+
+      for (let i = 0; i < children.length; i++) {
+        const childId = children[i];
+        if (childId === undefined) continue;
+
+        const childSummary = this.summaries.get(childId);
+        if (childSummary === undefined) continue;
+
+        const childMeasure = dimension.measure(childSummary);
+        const nextPos = dimension.add(pos, childMeasure);
+        const cmp = dimension.compare(nextPos, target);
+
+        if (cmp > 0 || (cmp === 0 && bias === "left")) {
+          // Target is in this child
+          current = childId;
+          found = true;
+          break;
+        }
+
+        // Skip this child
+        pos = nextPos;
+        index += this.countItems(childId);
+      }
+
+      if (!found) {
+        // Target is past all children
+        return index;
+      }
+    }
+  }
+
+  /**
    * Push an item to the end of the tree.
    * Returns a new tree (path copying), leaving the original unchanged.
    */
@@ -628,6 +782,69 @@ export class SumTree<T extends Summarizable<S>, S> {
     }
 
     return newTree;
+  }
+
+  /**
+   * Replace item at the given index with a new item.
+   * Returns a new tree (path copying), leaving the original unchanged.
+   */
+  replaceAt(index: number, item: T): SumTree<T, S> {
+    if (index < 0 || index >= this.length()) {
+      throw new Error(`Index ${index} out of bounds`);
+    }
+
+    const newTree = this.shallowClone();
+    const path = newTree.findLeafForIndex(index);
+    if (path.length === 0) {
+      return newTree;
+    }
+
+    // Clone the path
+    const clonedPath = newTree.clonePath(path);
+
+    // Replace in the leaf
+    const leafEntry = clonedPath[clonedPath.length - 1];
+    if (leafEntry === undefined) {
+      return newTree;
+    }
+
+    const leafData = newTree.arena.getItem(leafEntry.nodeId);
+    const items = leafData?.items ?? [];
+    items[leafEntry.indexInNode] = item;
+
+    // Update leaf
+    newTree.arena.setItem(leafEntry.nodeId, { items });
+
+    // Update summaries up the path
+    newTree.updateSummariesUp(clonedPath);
+
+    return newTree;
+  }
+
+  /**
+   * Replace a range of items with new items.
+   * Returns a new tree (path copying), leaving the original unchanged.
+   * This is useful for splits where one item becomes two.
+   */
+  spliceAt(index: number, deleteCount: number, ...items: T[]): SumTree<T, S> {
+    let tree: SumTree<T, S> = this;
+
+    // Remove items in reverse order to maintain indices
+    for (let i = deleteCount - 1; i >= 0; i--) {
+      if (index + i < tree.length()) {
+        tree = tree.removeAt(index + i);
+      }
+    }
+
+    // Insert new items
+    for (let i = items.length - 1; i >= 0; i--) {
+      const item = items[i];
+      if (item !== undefined) {
+        tree = tree.insertAt(index, item);
+      }
+    }
+
+    return tree;
   }
 
   /**

--- a/src/text/fragment.ts
+++ b/src/text/fragment.ts
@@ -82,6 +82,22 @@ export const visibleLinesDimension: Dimension<FragmentSummary, number> = {
   },
 };
 
+/** Dimension for seeking by total length (visible + deleted). */
+export const totalLenDimension: Dimension<FragmentSummary, number> = {
+  measure(summary: FragmentSummary): number {
+    return summary.visibleLen + summary.deletedLen;
+  },
+  compare(a: number, b: number): number {
+    return a - b;
+  },
+  add(a: number, b: number): number {
+    return a + b;
+  },
+  zero(): number {
+    return 0;
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Fragment construction
 // ---------------------------------------------------------------------------

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -23,6 +23,7 @@ import {
   deleteFragment,
   fragmentSummaryOps,
   splitFragment,
+  visibleLenDimension,
   withVisibility,
 } from "./fragment.js";
 import { MAX_LOCATOR, MIN_LOCATOR, compareLocators, locatorBetween } from "./locator.js";
@@ -556,164 +557,185 @@ export class TextBuffer {
       this.recordImplicitOp(opId, "insert");
     }
 
-    const frags = this.fragmentsArray();
-
-    // Find the position to insert: seek to the visible offset
-    const { leftLocator, rightLocator, insertLocator, insertIndex, afterRef, beforeRef } =
-      this.findInsertPosition(frags, offset);
-
-    // Use explicit insertLocator if provided (for split cases), otherwise compute via locatorBetween
-    const locator = insertLocator ?? locatorBetween(leftLocator, rightLocator);
+    // Fast path: use O(log n) seek and insert
+    const result = this.findInsertPositionFast(offset);
+    const locator = result.insertLocator ?? locatorBetween(result.leftLocator, result.rightLocator);
 
     // Create the new fragment
     const newFrag = createFragment(opId, 0, locator, text, true);
 
-    // Build new fragment array (no sort for local ops - undo relies on insertion order)
-    const newFrags = [...frags.slice(0, insertIndex), newFrag, ...frags.slice(insertIndex)];
-
-    // Rebuild the SumTree
-    this.fragments = SumTree.fromItems(newFrags, fragmentSummaryOps);
+    // Apply any split and insert in O(log n)
+    if (result.splitFragments !== undefined) {
+      // Need to split: replace original fragment with split parts, then insert new fragment
+      this.fragments = this.fragments.spliceAt(
+        result.splitIndex,
+        1,
+        result.splitFragments[0],
+        result.splitFragments[1],
+      );
+      this.fragments = this.fragments.insertAt(result.insertIndex, newFrag);
+    } else {
+      // No split needed: just insert
+      this.fragments = this.fragments.insertAt(result.insertIndex, newFrag);
+    }
 
     return {
       type: "insert",
       id: opId,
       text,
-      after: afterRef,
-      before: beforeRef,
+      after: result.afterRef,
+      before: result.beforeRef,
       version: cloneVersionVector(this._version),
       locator,
     };
   }
 
-  private findInsertPosition(
-    frags: Fragment[],
-    offset: number,
-  ): {
+  /**
+   * Find the insert position using O(log n) operations.
+   * Returns all metadata needed for the insert operation.
+   */
+  private findInsertPositionFast(offset: number): {
     leftLocator: Locator;
     rightLocator: Locator;
-    /** Explicit Locator for the new insert (computed for split cases to avoid collisions) */
     insertLocator?: Locator;
     insertIndex: number;
+    splitIndex: number;
+    splitFragments?: [Fragment, Fragment];
     afterRef: { insertionId: OperationId; offset: number };
     beforeRef: { insertionId: OperationId; offset: number };
   } {
-    if (frags.length === 0) {
+    const len = this.fragments.length();
+
+    // Empty tree case
+    if (len === 0) {
       return {
         leftLocator: MIN_LOCATOR,
         rightLocator: MAX_LOCATOR,
         insertIndex: 0,
+        splitIndex: 0,
         afterRef: { insertionId: MIN_OPERATION_ID, offset: 0 },
         beforeRef: { insertionId: MAX_OPERATION_ID, offset: 0 },
       };
     }
 
-    let visibleOffset = 0;
+    // Use O(log n) seek to find the fragment containing the offset
+    const { index, position: accumulatedVisible } = this.fragments.seekIndexAndPosition(
+      visibleLenDimension,
+      offset,
+      "right",
+    );
 
-    for (let i = 0; i < frags.length; i++) {
-      const frag = frags[i];
-      if (frag === undefined) continue;
-
-      if (frag.visible) {
-        if (visibleOffset + frag.length > offset) {
-          const localOffset = offset - visibleOffset;
-
-          // If localOffset === 0, insert BEFORE this fragment (at boundary)
-          // Don't split — that would create a zero-length fragment and use 2*0-1 = -1
-          if (localOffset === 0) {
-            const leftLocator = i > 0 ? (frags[i - 1]?.locator ?? MIN_LOCATOR) : MIN_LOCATOR;
-            const rightLocator = frag.locator;
-
-            return {
-              leftLocator,
-              rightLocator,
-              insertIndex: i,
-              afterRef:
-                i > 0 && frags[i - 1] !== undefined
-                  ? {
-                      insertionId: frags[i - 1]!.insertionId,
-                      offset: frags[i - 1]!.insertionOffset + frags[i - 1]!.length,
-                    }
-                  : { insertionId: MIN_OPERATION_ID, offset: 0 },
-              beforeRef: {
-                insertionId: frag.insertionId,
-                offset: frag.insertionOffset,
-              },
-            };
-          }
-
-          // The insert point is strictly inside this fragment — split it
-          const [left, right] = splitFragment(frag, localOffset);
-
-          // Replace the original fragment with the split pair
-          frags.splice(i, 1, left, right);
-
-          // Compute explicit Locator using the 2*k-1 scheme to avoid collisions
-          // with the 2*k scheme used for split fragments
-          const k = right.insertionOffset;
-          const insertLocator: Locator = {
-            levels: [...frag.baseLocator.levels, 2 * k - 1],
-          };
-
-          return {
-            leftLocator: left.locator,
-            rightLocator: right.locator,
-            insertLocator,
-            insertIndex: i + 1,
-            afterRef: {
-              insertionId: left.insertionId,
-              offset: left.insertionOffset + left.length,
-            },
-            beforeRef: {
-              insertionId: right.insertionId,
-              offset: right.insertionOffset,
-            },
-          };
-        }
-        visibleOffset += frag.length;
-
-        if (visibleOffset === offset) {
-          // Insert right after this fragment
-          const leftLocator = frag.locator;
-          const rightLocator =
-            i + 1 < frags.length ? (frags[i + 1]?.locator ?? MAX_LOCATOR) : MAX_LOCATOR;
-
-          return {
-            leftLocator,
-            rightLocator,
-            insertIndex: i + 1,
-            afterRef: {
-              insertionId: frag.insertionId,
-              offset: frag.insertionOffset + frag.length,
-            },
-            beforeRef: (() => {
-              const nextFrag = frags[i + 1];
-              if (nextFrag !== undefined) {
-                return {
-                  insertionId: nextFrag.insertionId,
-                  offset: nextFrag.insertionOffset,
-                };
+    // Handle insert at end
+    if (index >= len) {
+      const lastFrag = this.fragments.get(len - 1);
+      return {
+        leftLocator: lastFrag !== undefined ? lastFrag.locator : MIN_LOCATOR,
+        rightLocator: MAX_LOCATOR,
+        insertIndex: len,
+        splitIndex: len,
+        afterRef:
+          lastFrag !== undefined
+            ? {
+                insertionId: lastFrag.insertionId,
+                offset: lastFrag.insertionOffset + lastFrag.length,
               }
-              return { insertionId: MAX_OPERATION_ID, offset: 0 };
-            })(),
-          };
-        }
-      }
+            : { insertionId: MIN_OPERATION_ID, offset: 0 },
+        beforeRef: { insertionId: MAX_OPERATION_ID, offset: 0 },
+      };
     }
 
-    // Insert at the end
-    const lastFrag = frags[frags.length - 1];
+    const frag = this.fragments.get(index);
+    if (frag === undefined) {
+      // Should not happen, but handle gracefully
+      return {
+        leftLocator: MIN_LOCATOR,
+        rightLocator: MAX_LOCATOR,
+        insertIndex: index,
+        splitIndex: index,
+        afterRef: { insertionId: MIN_OPERATION_ID, offset: 0 },
+        beforeRef: { insertionId: MAX_OPERATION_ID, offset: 0 },
+      };
+    }
+
+    // Calculate local offset within the fragment
+    const localOffset = offset - accumulatedVisible;
+
+    // Get neighboring fragments for locator calculation
+    const prevFrag = index > 0 ? this.fragments.get(index - 1) : undefined;
+    const nextFrag = index + 1 < len ? this.fragments.get(index + 1) : undefined;
+
+    // Case 1: Insert at the start of a visible fragment (localOffset === 0 or fragment is invisible)
+    if (localOffset === 0 || !frag.visible) {
+      const leftLocator = prevFrag !== undefined ? prevFrag.locator : MIN_LOCATOR;
+      const rightLocator = frag.locator;
+
+      return {
+        leftLocator,
+        rightLocator,
+        insertIndex: index,
+        splitIndex: index,
+        afterRef:
+          prevFrag !== undefined
+            ? {
+                insertionId: prevFrag.insertionId,
+                offset: prevFrag.insertionOffset + prevFrag.length,
+              }
+            : { insertionId: MIN_OPERATION_ID, offset: 0 },
+        beforeRef: {
+          insertionId: frag.insertionId,
+          offset: frag.insertionOffset,
+        },
+      };
+    }
+
+    // Case 2: Insert at the end of a visible fragment
+    if (localOffset >= frag.length) {
+      const leftLocator = frag.locator;
+      const rightLocator = nextFrag !== undefined ? nextFrag.locator : MAX_LOCATOR;
+
+      return {
+        leftLocator,
+        rightLocator,
+        insertIndex: index + 1,
+        splitIndex: index + 1,
+        afterRef: {
+          insertionId: frag.insertionId,
+          offset: frag.insertionOffset + frag.length,
+        },
+        beforeRef:
+          nextFrag !== undefined
+            ? {
+                insertionId: nextFrag.insertionId,
+                offset: nextFrag.insertionOffset,
+              }
+            : { insertionId: MAX_OPERATION_ID, offset: 0 },
+      };
+    }
+
+    // Case 3: Insert in the middle of a visible fragment - need to split
+    const [left, right] = splitFragment(frag, localOffset);
+
+    // Compute explicit Locator using the 2*k-1 scheme to avoid collisions
+    const k = right.insertionOffset;
+    const insertLocator: Locator = {
+      levels: [...frag.baseLocator.levels, 2 * k - 1],
+    };
+
     return {
-      leftLocator: lastFrag !== undefined ? lastFrag.locator : MIN_LOCATOR,
-      rightLocator: MAX_LOCATOR,
-      insertIndex: frags.length,
-      afterRef:
-        lastFrag !== undefined
-          ? {
-              insertionId: lastFrag.insertionId,
-              offset: lastFrag.insertionOffset + lastFrag.length,
-            }
-          : { insertionId: MIN_OPERATION_ID, offset: 0 },
-      beforeRef: { insertionId: MAX_OPERATION_ID, offset: 0 },
+      leftLocator: left.locator,
+      rightLocator: right.locator,
+      insertLocator,
+      insertIndex: index + 1, // Insert after the left split part
+      splitIndex: index,
+      splitFragments: [left, right],
+      afterRef: {
+        insertionId: left.insertionId,
+        offset: left.insertionOffset + left.length,
+      },
+      beforeRef: {
+        insertionId: right.insertionId,
+        offset: right.insertionOffset,
+      },
     };
   }
 


### PR DESCRIPTION
## Summary

- Replace O(n) `fromItems()` tree rebuild in `insertInternal` with O(log n) incremental operations
- Add `seekIndexAndPosition()` to find array index at dimension position
- Add `replaceAt()` for O(log n) single-item replacement
- Add `spliceAt()` for O(log n) multi-item replacement (useful for fragment splits)
- Add `totalLenDimension` to fragment module for seeking by total length

## Performance Impact

The `insertInternal` method now uses:
1. `seekIndexAndPosition()` to find insert position in O(log n)
2. `spliceAt()` to handle fragment splits in O(log n)
3. `insertAt()` to add new fragment in O(log n)

This reduces sequential insert complexity from **O(n²)** to **O(n log n)**.

### Before (with O(n) rebuild per insert)
Each insert triggered a full `SumTree.fromItems()` rebuild, making sequential inserts O(n²) overall.

### After (with O(log n) incremental operations)
Each insert uses tree path-copying operations, making sequential inserts O(n log n) overall.

## What's Not Fixed (Yet)

The following operations still use `fromItems()` and could be optimized in follow-up PRs:
- `deleteInternal` - still uses fromItems
- `recomputeVisibility` - still uses fromItems
- `applyRemoteInsertDirect` - still uses fromItems
- `applyRemoteDelete` - still uses fromItems

## Test plan

- [x] All existing text-buffer tests pass (93 tests)
- [x] All SumTree tests pass (53 tests including new tests)
- [x] Added tests for new SumTree methods (seekIndexAndPosition, replaceAt, spliceAt)
- [x] Verified insert performance improvement with local benchmarks

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)