### PR TITLE
feat(sum-tree): add O(log n) cursor and tree primitives

### DIFF
--- a/src/sum-tree/index.ts
+++ b/src/sum-tree/index.ts
@@ -88,6 +88,53 @@ export class Cursor<T extends Summarizable<S>, S, D> {
     return this._atEnd;
   }
 
+  /**
+   * Get the item index (0-based position) of the current cursor position.
+   * This counts all items before the current position in the tree.
+   * Returns tree length if cursor is at end or stack is empty.
+   */
+  itemIndex(): number {
+    if (this._atEnd || this.stack.length === 0) {
+      return this.tree.length();
+    }
+
+    const arena = this.tree.getArena();
+    let index = 0;
+
+    for (let i = 0; i < this.stack.length; i++) {
+      const entry = this.stack[i];
+      if (entry === undefined) continue;
+
+      if (arena.isLeaf(entry.nodeId)) {
+        // Leaf node: add the childIndex (position within the leaf)
+        index += entry.childIndex;
+      } else {
+        // Internal node: find which child we descended into
+        // by looking at the next stack entry's nodeId
+        const nextEntry = this.stack[i + 1];
+        if (nextEntry === undefined) continue;
+
+        // Find which child index contains nextEntry.nodeId
+        const count = arena.getCount(entry.nodeId);
+        for (let j = 0; j < count; j++) {
+          const childId = arena.getChild(entry.nodeId, j);
+          if (childId === nextEntry.nodeId) {
+            // Child j is where we descended, count items in children before j
+            for (let k = 0; k < j; k++) {
+              const kid = arena.getChild(entry.nodeId, k);
+              if (kid !== INVALID_NODE_ID) {
+                index += this.tree.countItemsInSubtree(kid);
+              }
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    return index;
+  }
+
   /** Reset cursor to the beginning */
   reset(): void {
     this.stack = [];
@@ -569,6 +616,11 @@ export class SumTree<T extends Summarizable<S>, S> {
     return data?.items ?? [];
   }
 
+  /** Count items in a subtree (for cursor use) */
+  countItemsInSubtree(nodeId: NodeId): number {
+    return this.countItems(nodeId);
+  }
+
   /**
    * Create a cursor for navigating the tree in the given dimension.
    */
@@ -669,6 +721,44 @@ export class SumTree<T extends Summarizable<S>, S> {
     } else {
       newTree.updateSummariesUp(clonedPath);
     }
+
+    return newTree;
+  }
+
+  /**
+   * Replace item at the given index with a new item.
+   * Returns a new tree (path copying), leaving the original unchanged.
+   * Does not change the tree structure (no splits or merges needed).
+   */
+  replaceAt(index: number, item: T): SumTree<T, S> {
+    if (index < 0 || index >= this.length()) {
+      throw new Error(`Index ${index} out of bounds`);
+    }
+
+    const newTree = this.shallowClone();
+    const path = newTree.findLeafForIndex(index);
+    if (path.length === 0) {
+      return newTree;
+    }
+
+    // Clone the path
+    const clonedPath = newTree.clonePath(path);
+
+    // Replace in the leaf
+    const leafEntry = clonedPath[clonedPath.length - 1];
+    if (leafEntry === undefined) {
+      return newTree;
+    }
+
+    const leafData = newTree.arena.getItem(leafEntry.nodeId);
+    const items = leafData?.items ?? [];
+    items[leafEntry.indexInNode] = item;
+
+    // Update leaf (count stays the same)
+    newTree.arena.setItem(leafEntry.nodeId, { items });
+
+    // Update summaries up the path
+    newTree.updateSummariesUp(clonedPath);
 
     return newTree;
   }

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -556,6 +556,8 @@ export class TextBuffer {
       this.recordImplicitOp(opId, "insert");
     }
 
+    // Use the original O(n) approach for correctness (maintains fragment ordering)
+    // TODO: Issue #33 - Implement Locator-keyed SumTree for O(log n) insertion
     const frags = this.fragmentsArray();
 
     // Find the position to insert: seek to the visible offset


### PR DESCRIPTION
## Summary

- Add `Cursor.itemIndex()` for O(log n) position-to-index conversion
- Add `SumTree.replaceAt()` for O(log n) in-place item replacement
- Add `SumTree.countItemsInSubtree()` for cursor support

These primitives support the Locator-keyed SumTree optimization described in #33.

## Details

See issue comment for full research findings: https://github.com/iamnbutler/crdt/issues/33#issuecomment-4116531809

### Key Finding

Simple cursor-based insertion using visible-offset seeking doesn't maintain Locator order, which is required for CRDT convergence. The full fix requires implementing a Locator-keyed SumTree (Option A from #33).

### What's Included

These O(log n) primitives are building blocks for the full optimization:

1. **`Cursor.itemIndex()`**: Returns the 0-based item index of the current cursor position by walking the cursor stack and counting items in preceding children.

2. **`SumTree.replaceAt(index, item)`**: Replaces an item at a given index using O(log n) path copying. Useful for updating fragments without rebuilding the tree.

3. **`SumTree.countItemsInSubtree(nodeId)`**: Public wrapper for the internal `countItems` method, needed by `itemIndex()`.

## Test plan

- [x] Existing SumTree tests pass
- [x] Existing text-buffer tests pass
- [x] No regressions (property test failures are pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)