### PR TITLE
perf(bench): use O(1) length() accessor instead of getText().length

### DIFF
--- a/benchmarks/comparison.ts
+++ b/benchmarks/comparison.ts
@@ -31,6 +31,8 @@ interface TextCRDTAdapter {
   insert(doc: unknown, position: number, text: string): void;
   delete(doc: unknown, position: number, length: number): void;
   getText(doc: unknown): string;
+  /** O(1) length accessor - avoids materializing the full text string */
+  length(doc: unknown): number;
   serialize(doc: unknown): Uint8Array | string;
   deserialize(data: Uint8Array | string): unknown;
 }
@@ -52,6 +54,9 @@ const ourAdapter: TextCRDTAdapter = {
   },
   getText(doc: unknown) {
     return (doc as TextBuffer).getText();
+  },
+  length(doc: unknown) {
+    return (doc as TextBuffer).length;
   },
   serialize(doc: unknown) {
     // Use getText for simple serialization (no toJSON available)
@@ -90,6 +95,10 @@ const loroAdapter: TextCRDTAdapter = {
     const loroDoc = doc as LoroDoc;
     return loroDoc.getText("content").toString();
   },
+  length(doc: unknown) {
+    const loroDoc = doc as LoroDoc;
+    return loroDoc.getText("content").length;
+  },
   serialize(doc: unknown) {
     return (doc as LoroDoc).export({ mode: "snapshot" });
   },
@@ -127,6 +136,10 @@ const yjsAdapter: TextCRDTAdapter = {
   getText(doc: unknown) {
     const yDoc = doc as Y.Doc;
     return yDoc.getText("content").toString();
+  },
+  length(doc: unknown) {
+    const yDoc = doc as Y.Doc;
+    return yDoc.getText("content").length;
   },
   serialize(doc: unknown) {
     return Y.encodeStateAsUpdate(doc as Y.Doc);
@@ -171,6 +184,10 @@ const automergeAdapter: TextCRDTAdapter = {
   getText(doc: unknown) {
     const amDoc = doc as Automerge.Doc<AutomergeDoc>;
     return amDoc.text;
+  },
+  length(doc: unknown) {
+    const amDoc = doc as Automerge.Doc<AutomergeDoc>;
+    return amDoc.text.length;
   },
   serialize(doc: unknown) {
     return Automerge.save(doc as Automerge.Doc<AutomergeDoc>);
@@ -242,7 +259,7 @@ group("insert-at-end", () => {
     bench(adapter.name, () => {
       let doc = adapter.create();
       for (let i = 0; i < SEQUENTIAL_OPS; i++) {
-        const len = adapter.getText(doc).length;
+        const len = adapter.length(doc);
         // Automerge returns new doc on change
         const result = adapter.insert(doc, len, "x");
         if (result !== undefined) doc = result;
@@ -270,7 +287,7 @@ group("insert-at-middle", () => {
     bench(adapter.name, () => {
       let doc = adapter.create();
       for (let i = 0; i < SEQUENTIAL_OPS; i++) {
-        const len = adapter.getText(doc).length;
+        const len = adapter.length(doc);
         const mid = Math.floor(len / 2);
         const result = adapter.insert(doc, mid, "x");
         if (result !== undefined) doc = result;
@@ -286,7 +303,7 @@ group("delete-from-end", () => {
     bench(adapter.name, () => {
       let doc = adapter.fromString("x".repeat(SEQUENTIAL_OPS));
       for (let i = 0; i < SEQUENTIAL_OPS; i++) {
-        const len = adapter.getText(doc).length;
+        const len = adapter.length(doc);
         if (len > 0) {
           const result = adapter.delete(doc, len - 1, 1);
           if (result !== undefined) doc = result;
@@ -302,7 +319,7 @@ group("delete-from-start", () => {
     bench(adapter.name, () => {
       let doc = adapter.fromString("x".repeat(SEQUENTIAL_OPS));
       for (let i = 0; i < SEQUENTIAL_OPS; i++) {
-        const len = adapter.getText(doc).length;
+        const len = adapter.length(doc);
         if (len > 0) {
           const result = adapter.delete(doc, 0, 1);
           if (result !== undefined) doc = result;


### PR DESCRIPTION
## Summary

- Add `length(doc)` method to `TextCRDTAdapter` interface for O(1) length access
- Implement O(1) length for all adapters (TextBuffer.length, LoroText.length, Y.Text.length, string.length)
- Update 4 benchmark loops to use `adapter.length(doc)` instead of `adapter.getText(doc).length`

## Problem

The insert and delete benchmarks were calling `getText().length` on every iteration:

```typescript
for (let i = 0; i < SEQUENTIAL_OPS; i++) {
  const len = adapter.getText(doc).length;  // <-- O(n) string materialization!
  adapter.insert(doc, len, "x");
}
```

With 1000 operations per benchmark, this means:
- 1000 full text materializations per benchmark
- O(n) tree traversal + O(n) string concatenation for each call
- Inflates benchmark times unnecessarily

## Solution

All libraries already have O(1) length accessors:
- **@iamnbutler/crdt**: `TextBuffer.length` uses `fragments.summary().visibleLen`
- **Loro**: `LoroText.length` is O(1)
- **Yjs**: `Y.Text.length` is O(1)
- **Automerge**: `doc.text.length` (native string)

This PR adds a `length()` method to the adapter interface and uses it in all benchmark loops.

## Test plan

- [x] `biome check benchmarks/comparison.ts` passes
- [ ] Run benchmarks locally with `bun run bench` to verify correct behavior
- [ ] Compare benchmark results before/after to quantify the improvement

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)