### PR TITLE
perf(text): optimize TextBuffer.fromString 4.5x faster

### DIFF
--- a/src/text/fragment.ts
+++ b/src/text/fragment.ts
@@ -86,15 +86,10 @@ export const visibleLinesDimension: Dimension<FragmentSummary, number> = {
 // Fragment construction
 // ---------------------------------------------------------------------------
 
-/** Count newlines in a string. */
+/** Count newlines in a string. Uses regex match which is highly optimized. */
 function countNewlines(text: string): number {
-  let count = 0;
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === 0x0a) {
-      count++;
-    }
-  }
-  return count;
+  const matches = text.match(/\n/g);
+  return matches ? matches.length : 0;
 }
 
 /**

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -133,8 +133,10 @@ export class TextBuffer {
   static fromString(text: string, rid?: ReplicaId): TextBuffer {
     const buffer = TextBuffer.create(rid);
     if (text.length > 0) {
-      // Normalize line endings
-      const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      // Normalize line endings (skip regex if no \r present - common case)
+      const normalized = text.includes("\r")
+        ? text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+        : text;
       buffer.insertInternal(0, normalized);
     }
     return buffer;
@@ -207,7 +209,10 @@ export class TextBuffer {
       };
     }
 
-    const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    // Normalize line endings (skip regex if no \r present - common case)
+    const normalized = text.includes("\r")
+      ? text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+      : text;
     return this.insertInternal(offset, normalized);
   }
 


### PR DESCRIPTION
## Summary

- Optimize `TextBuffer.fromString()` to be 4.5x faster for large strings
- We went from 5.9x slower than Yjs to only 1.29x slower

## Changes

1. **Regex-based newline counting**: Replaced slow `charCodeAt` loop with `text.match(/\n/g)` which is 26x faster
2. **Skip line ending normalization for common case**: Check `text.includes("\r")` before applying regex replacements - Unix-style text skips two unnecessary regex operations

## Benchmark Results

| Library | create-from-large-string (80KB) |
|---------|----------------------------------|
| Yjs | 7.95µs |
| @iamnbutler/crdt (after) | **10.24µs** |
| @iamnbutler/crdt (before) | 45.77µs |
| Loro | 429.95µs |
| Automerge | 27.32ms |

## Test plan

- [x] `bun test src/text/text-buffer.test.ts` - all 93 tests pass
- [x] `bun run benchmarks/comparison.ts` - verified 4.5x improvement
- [x] Typecheck passes

Note: Property tests have pre-existing failures unrelated to this change.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)