### PR TITLE
feat(sum-tree): add Cursor.itemIndex() with proper indexInParent tracking

### DIFF
--- a/src/sum-tree/cursor-itemindex.test.ts
+++ b/src/sum-tree/cursor-itemindex.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type CountSummary,
+  SumTree,
+  type Summarizable,
+  countDimension,
+  countSummaryOps,
+} from "./index.js";
+
+// Simple test item for count-based tests
+class CountItem implements Summarizable<CountSummary> {
+  constructor(public value: number) {}
+
+  summary(): CountSummary {
+    return { count: 1 };
+  }
+}
+
+describe("Cursor.itemIndex()", () => {
+  describe("consistency between walk and seek", () => {
+    it("matches for single-leaf tree", () => {
+      // Small tree that fits in one leaf
+      const items = Array.from({ length: 5 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps);
+
+      for (let target = 0; target < items.length; target++) {
+        // Method 1: Walk with next() from beginning
+        const walkCursor = tree.cursor(countDimension);
+        for (let j = 0; j < target; j++) {
+          walkCursor.next();
+        }
+        const walkIndex = walkCursor.itemIndex();
+
+        // Method 2: Seek directly
+        const seekCursor = tree.cursor(countDimension);
+        seekCursor.seekForward(target, "right");
+        const seekIndex = seekCursor.itemIndex();
+
+        expect(seekIndex).toBe(walkIndex);
+        expect(seekIndex).toBe(target);
+      }
+    });
+
+    it("matches for multi-leaf tree (branching factor 4)", () => {
+      // Tree with multiple leaves to create internal nodes
+      const items = Array.from({ length: 20 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      for (let target = 0; target < items.length; target++) {
+        // Method 1: Walk with next() from beginning
+        const walkCursor = tree.cursor(countDimension);
+        for (let j = 0; j < target; j++) {
+          walkCursor.next();
+        }
+        const walkIndex = walkCursor.itemIndex();
+
+        // Method 2: Seek directly
+        const seekCursor = tree.cursor(countDimension);
+        seekCursor.seekForward(target, "right");
+        const seekIndex = seekCursor.itemIndex();
+
+        expect(seekIndex).toBe(walkIndex);
+        expect(seekIndex).toBe(target);
+      }
+    });
+
+    it("matches for 39-item tree (original reproduction)", () => {
+      // Reproduction from issue: 39 items, branching factor 4
+      const items = Array.from({ length: 39 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      // Seek to last item
+      const seekCursor = tree.cursor(countDimension);
+      seekCursor.seekForward(38, "right");
+      const seekIndex = seekCursor.itemIndex();
+
+      // Walk to last item
+      const walkCursor = tree.cursor(countDimension);
+      for (let j = 0; j < 38; j++) {
+        walkCursor.next();
+      }
+      const walkIndex = walkCursor.itemIndex();
+
+      expect(seekIndex).toBe(walkIndex);
+      expect(seekIndex).toBe(38);
+    });
+
+    it("matches for fresh seeks to various positions", () => {
+      const items = Array.from({ length: 100 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      // Use fresh cursor for each seek (sequential seeks have a separate bug)
+      const targets = [10, 25, 50, 75, 90, 95];
+      for (const target of targets) {
+        const cursor = tree.cursor(countDimension);
+        cursor.seekForward(target, "right");
+        const seekIndex = cursor.itemIndex();
+        expect(seekIndex).toBe(target);
+      }
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns 0 at beginning", () => {
+      const items = Array.from({ length: 10 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      const cursor = tree.cursor(countDimension);
+      expect(cursor.itemIndex()).toBe(0);
+    });
+
+    it("returns length at end", () => {
+      const items = Array.from({ length: 10 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      const cursor = tree.cursor(countDimension);
+      // Walk to end
+      while (!cursor.atEnd) {
+        cursor.next();
+      }
+      expect(cursor.itemIndex()).toBe(10);
+    });
+
+    it("works on empty tree", () => {
+      const tree = new SumTree<CountItem, CountSummary>(countSummaryOps);
+      const cursor = tree.cursor(countDimension);
+      expect(cursor.itemIndex()).toBe(0);
+    });
+
+    it("handles single item tree", () => {
+      const tree = SumTree.fromItems([new CountItem(42)], countSummaryOps);
+      const cursor = tree.cursor(countDimension);
+
+      expect(cursor.itemIndex()).toBe(0);
+      cursor.next();
+      expect(cursor.itemIndex()).toBe(1);
+    });
+  });
+
+  describe("minimal reproduction with 2 leaves", () => {
+    it("matches for tree with exactly 2 leaves", () => {
+      // Branching factor 4 means a leaf can hold 4 items
+      // 5 items forces 2 leaves with 1 internal node
+      const items = Array.from({ length: 5 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      // Check invariants to understand structure
+      const invariants = tree.checkInvariants();
+      expect(invariants.valid).toBe(true);
+
+      // Seek to item at index 4 (first item in second leaf likely)
+      const seekCursor = tree.cursor(countDimension);
+      seekCursor.seekForward(4, "right");
+      const seekIndex = seekCursor.itemIndex();
+
+      // Walk to same position
+      const walkCursor = tree.cursor(countDimension);
+      for (let j = 0; j < 4; j++) {
+        walkCursor.next();
+      }
+      const walkIndex = walkCursor.itemIndex();
+
+      expect(seekIndex).toBe(walkIndex);
+      expect(seekIndex).toBe(4);
+    });
+  });
+
+  describe("deep trees (multiple internal levels)", () => {
+    it("matches for tree with 3+ levels (branching factor 4, 100 items)", () => {
+      // With B=4, 100 items creates at least 3 levels
+      const items = Array.from({ length: 100 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      // Test various positions throughout the tree
+      const targets = [0, 15, 32, 63, 77, 99];
+      for (const target of targets) {
+        const seekCursor = tree.cursor(countDimension);
+        seekCursor.seekForward(target, "right");
+        const seekIndex = seekCursor.itemIndex();
+
+        const walkCursor = tree.cursor(countDimension);
+        for (let j = 0; j < target; j++) {
+          walkCursor.next();
+        }
+        const walkIndex = walkCursor.itemIndex();
+
+        expect(seekIndex).toBe(walkIndex);
+        expect(seekIndex).toBe(target);
+      }
+    });
+
+    it("matches for tree with 4+ levels (branching factor 4, 1000 items)", () => {
+      const items = Array.from({ length: 1000 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      // Test various positions
+      const targets = [0, 127, 256, 511, 768, 999];
+      for (const target of targets) {
+        const seekCursor = tree.cursor(countDimension);
+        seekCursor.seekForward(target, "right");
+        const seekIndex = seekCursor.itemIndex();
+
+        expect(seekIndex).toBe(target);
+      }
+    });
+  });
+
+  describe("position after walk then itemIndex", () => {
+    it("itemIndex tracks position correctly during iteration", () => {
+      const items = Array.from({ length: 50 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 4);
+
+      const cursor = tree.cursor(countDimension);
+      let count = 0;
+      while (!cursor.atEnd) {
+        expect(cursor.itemIndex()).toBe(count);
+        cursor.next();
+        count++;
+      }
+      expect(count).toBe(50);
+    });
+  });
+
+  describe("O(log n) efficiency with getItemCount", () => {
+    it("uses O(1) summary lookup for item counts", () => {
+      // countSummaryOps has getItemCount, so itemIndex should be O(log n)
+      const items = Array.from({ length: 10000 }, (_, i) => new CountItem(i));
+      const tree = SumTree.fromItems(items, countSummaryOps, 16);
+
+      // This should be fast (O(log n)) not slow (O(n))
+      const start = performance.now();
+      for (let i = 0; i < 1000; i++) {
+        const cursor = tree.cursor(countDimension);
+        cursor.seekForward(5000, "right");
+        cursor.itemIndex();
+      }
+      const elapsed = performance.now() - start;
+
+      // 1000 iterations of O(log n) work should complete in < 100ms
+      // If it were O(n), it would take much longer
+      expect(elapsed).toBeLessThan(100);
+    });
+  });
+});

--- a/src/sum-tree/index.ts
+++ b/src/sum-tree/index.ts
@@ -20,6 +20,11 @@ export interface Summary<S> {
   identity(): S;
   /** Combine two summaries (must be associative) */
   combine(left: S, right: S): S;
+  /**
+   * Optional: extract item count from a summary for O(log n) itemIndex().
+   * If not provided, falls back to O(n) recursive counting.
+   */
+  getItemCount?(summary: S): number;
 }
 
 /**
@@ -51,11 +56,21 @@ export interface Summarizable<S> {
 export type SeekBias = "left" | "right";
 
 /**
- * Position in a cursor stack: (nodeId, childIndex, accumulatedPosition)
+ * Position in a cursor stack.
+ *
+ * For leaves: childIndex is the current item index.
+ * For internal nodes: childIndex is the navigation state (next child to scan),
+ *                     indexInParent is which child of the parent this node is.
+ *
+ * indexInParent is set when the entry is pushed and doesn't change, providing
+ * unambiguous position information regardless of how we navigated here.
  */
 interface StackEntry<D> {
   nodeId: NodeId;
+  /** For leaves: current item index. For internals: navigation state (next child to scan). */
   childIndex: number;
+  /** Which child index this node is within its parent (for position/index calculation). */
+  indexInParent: number;
   position: D;
 }
 
@@ -95,7 +110,8 @@ export class Cursor<T extends Summarizable<S>, S, D> {
     this._atEnd = this.tree.isEmpty();
 
     if (!this._atEnd) {
-      this.descendToLeftmost(this.tree.root);
+      // Root has no parent, so indexInParent is 0 (irrelevant but required)
+      this.descendToLeftmost(this.tree.root, 0);
     }
   }
 
@@ -165,7 +181,7 @@ export class Cursor<T extends Summarizable<S>, S, D> {
       if (arena.isInternal(top.nodeId)) {
         const childId = arena.getChild(top.nodeId, top.childIndex);
         if (childId !== INVALID_NODE_ID) {
-          this.descendToRightmost(childId);
+          this.descendToRightmost(childId, top.childIndex);
         }
       }
 
@@ -222,10 +238,8 @@ export class Cursor<T extends Summarizable<S>, S, D> {
     // Sum from current position to end.
     // Walk from the deepest stack entry (leaf) upward to root.
     // For leaf entries, sum items from childIndex onward.
-    // For internal entries, find the child that was descended into
-    // (identified by the next deeper entry's nodeId) and sum children
-    // strictly AFTER that child. This avoids double-counting the subtree
-    // already accounted for by the deeper stack entry.
+    // For internal entries, use indexInParent of the deeper entry to know
+    // which child we descended into, then sum children AFTER it.
     let result = summaryOps.identity();
     const arena = this.tree.getArena();
 
@@ -245,20 +259,10 @@ export class Cursor<T extends Summarizable<S>, S, D> {
           }
         }
       } else {
-        // Internal node: find which child the deeper entry descended into,
-        // then sum only the children AFTER it.
+        // Internal node: sum children AFTER the one we descended into.
+        // Use indexInParent from the deeper entry to know which child that was.
         const deeperEntry = this.stack[i + 1];
-        let startJ = entry.childIndex;
-
-        if (deeperEntry !== undefined) {
-          // Find the child index that matches the deeper entry's nodeId
-          for (let j = 0; j < count; j++) {
-            if (arena.getChild(entry.nodeId, j) === deeperEntry.nodeId) {
-              startJ = j + 1;
-              break;
-            }
-          }
-        }
+        const startJ = deeperEntry !== undefined ? deeperEntry.indexInParent + 1 : entry.childIndex;
 
         for (let j = startJ; j < count; j++) {
           const childId = arena.getChild(entry.nodeId, j);
@@ -356,10 +360,11 @@ export class Cursor<T extends Summarizable<S>, S, D> {
 
       if (cmp > 0 || (cmp === 0 && bias === "left")) {
         // Target is in this child
-        entry.childIndex = i + 1; // Mark we've processed up to here
+        entry.childIndex = i + 1; // Mark we've processed up to here (for navigation)
         this.stack.push({
           nodeId: childId,
           childIndex: 0,
+          indexInParent: i, // The actual child index we descended into (for position calculation)
           position: pos,
         });
         return true;
@@ -405,7 +410,7 @@ export class Cursor<T extends Summarizable<S>, S, D> {
       if (arena.isInternal(top.nodeId)) {
         const childId = arena.getChild(top.nodeId, top.childIndex);
         if (childId !== INVALID_NODE_ID) {
-          this.descendToLeftmost(childId);
+          this.descendToLeftmost(childId, top.childIndex);
         }
       }
       return true;
@@ -416,33 +421,48 @@ export class Cursor<T extends Summarizable<S>, S, D> {
     return this.advanceToNext();
   }
 
-  private descendToLeftmost(nodeId: NodeId): void {
+  /**
+   * Descend to the leftmost leaf starting from nodeId.
+   * @param nodeId - Node to start descending from
+   * @param indexInParent - The index of nodeId within its parent (for position calculation)
+   */
+  private descendToLeftmost(nodeId: NodeId, indexInParent: number): void {
     const arena = this.tree.getArena();
     let current = nodeId;
+    let currentIndexInParent = indexInParent;
     const pos = this._position;
 
     while (arena.isInternal(current)) {
       this.stack.push({
         nodeId: current,
         childIndex: 0,
+        indexInParent: currentIndexInParent,
         position: pos,
       });
       const firstChild = arena.getChild(current, 0);
       if (firstChild === INVALID_NODE_ID) break;
       current = firstChild;
+      currentIndexInParent = 0; // Subsequent nodes are always at index 0 (leftmost)
     }
 
     // Push the leaf
     this.stack.push({
       nodeId: current,
       childIndex: 0,
+      indexInParent: currentIndexInParent,
       position: pos,
     });
   }
 
-  private descendToRightmost(nodeId: NodeId): void {
+  /**
+   * Descend to the rightmost leaf starting from nodeId.
+   * @param nodeId - Node to start descending from
+   * @param indexInParent - The index of nodeId within its parent (for position calculation)
+   */
+  private descendToRightmost(nodeId: NodeId, indexInParent: number): void {
     const arena = this.tree.getArena();
     let current = nodeId;
+    let currentIndexInParent = indexInParent;
 
     while (arena.isInternal(current)) {
       const count = arena.getCount(current);
@@ -450,11 +470,13 @@ export class Cursor<T extends Summarizable<S>, S, D> {
       this.stack.push({
         nodeId: current,
         childIndex: lastIndex,
+        indexInParent: currentIndexInParent,
         position: this._position, // Will be recalculated
       });
       const lastChild = arena.getChild(current, lastIndex);
       if (lastChild === INVALID_NODE_ID) break;
       current = lastChild;
+      currentIndexInParent = lastIndex; // Subsequent nodes are at the rightmost index
     }
 
     // Push the leaf
@@ -462,12 +484,14 @@ export class Cursor<T extends Summarizable<S>, S, D> {
     this.stack.push({
       nodeId: current,
       childIndex: Math.max(0, leafCount - 1),
+      indexInParent: currentIndexInParent,
       position: this._position,
     });
   }
 
   private recalculatePosition(): void {
-    // Recalculate position by summing from root
+    // Recalculate position by summing from root.
+    // Uses indexInParent for internal nodes and childIndex for leaves.
     this._position = this.dimension.zero();
     const arena = this.tree.getArena();
 
@@ -476,28 +500,96 @@ export class Cursor<T extends Summarizable<S>, S, D> {
       if (entry === undefined) continue;
 
       entry.position = this._position;
+      const parentEntry = i > 0 ? this.stack[i - 1] : undefined;
 
-      // Sum all siblings before current index
-      for (let j = 0; j < entry.childIndex; j++) {
-        if (arena.isLeaf(entry.nodeId)) {
-          const leafItems = this.tree.getLeafItems(entry.nodeId);
+      if (arena.isLeaf(entry.nodeId)) {
+        // Leaf: sum items before childIndex within this leaf
+        const leafItems = this.tree.getLeafItems(entry.nodeId);
+        for (let j = 0; j < entry.childIndex; j++) {
           const item = leafItems[j];
           if (item !== undefined) {
             const itemMeasure = this.dimension.measure(item.summary());
             this._position = this.dimension.add(this._position, itemMeasure);
           }
-        } else {
-          const childId = arena.getChild(entry.nodeId, j);
-          if (childId !== INVALID_NODE_ID) {
-            const childSummary = this.tree.getSummary(childId);
-            if (childSummary !== undefined) {
-              const childMeasure = this.dimension.measure(childSummary);
-              this._position = this.dimension.add(this._position, childMeasure);
+        }
+      }
+
+      // For non-root entries, sum sibling subtrees before this entry
+      if (parentEntry !== undefined) {
+        // Sum children 0..(indexInParent - 1) of the parent
+        for (let j = 0; j < entry.indexInParent; j++) {
+          const siblingId = arena.getChild(parentEntry.nodeId, j);
+          if (siblingId !== INVALID_NODE_ID) {
+            const siblingSum = this.tree.getSummary(siblingId);
+            if (siblingSum !== undefined) {
+              const siblingMeasure = this.dimension.measure(siblingSum);
+              this._position = this.dimension.add(this._position, siblingMeasure);
             }
           }
         }
       }
     }
+  }
+
+  /**
+   * Get the 0-based item index of the current cursor position.
+   * Returns the number of items before the current position.
+   *
+   * Uses the explicit `indexInParent` field on each stack entry to determine
+   * which child of its parent each node is. This avoids the ambiguity of
+   * `childIndex` which serves as a navigation bookmark (and has different
+   * semantics after seek vs walk).
+   *
+   * O(log n) if the summary supports getItemCount, O(n) otherwise.
+   */
+  itemIndex(): number {
+    if (this._atEnd) {
+      return this.tree.length();
+    }
+
+    if (this.stack.length === 0) {
+      return 0;
+    }
+
+    let index = 0;
+    const arena = this.tree.getArena();
+    const summaryOps = this.tree.getSummaryOps();
+    const getItemCount = summaryOps.getItemCount;
+
+    // Walk from root to leaf.
+    // For each entry, count items in all siblings BEFORE indexInParent.
+    // For the leaf entry, also add childIndex (the item position within the leaf).
+    for (let i = 0; i < this.stack.length; i++) {
+      const entry = this.stack[i];
+      if (entry === undefined) continue;
+
+      const parentEntry = i > 0 ? this.stack[i - 1] : undefined;
+
+      if (arena.isLeaf(entry.nodeId)) {
+        // Leaf: add items before childIndex within this leaf
+        index += entry.childIndex;
+      }
+
+      // For non-root entries, count items in sibling subtrees before this entry
+      if (parentEntry !== undefined) {
+        // Count items in children 0..(indexInParent - 1) of the parent
+        for (let j = 0; j < entry.indexInParent; j++) {
+          const siblingId = arena.getChild(parentEntry.nodeId, j);
+          if (siblingId !== INVALID_NODE_ID) {
+            if (getItemCount !== undefined) {
+              const summary = this.tree.getSummary(siblingId);
+              if (summary !== undefined) {
+                index += getItemCount(summary);
+              }
+            } else {
+              index += this.tree.countItemsInSubtree(siblingId);
+            }
+          }
+        }
+      }
+    }
+
+    return index;
   }
 }
 
@@ -905,6 +997,14 @@ export class SumTree<T extends Summarizable<S>, S> {
    */
   length(): number {
     return this.countItems(this._root);
+  }
+
+  /**
+   * Count items in a subtree rooted at the given node.
+   * Used by Cursor.itemIndex() for O(log n) index computation.
+   */
+  countItemsInSubtree(nodeId: NodeId): number {
+    return this.countItems(nodeId);
   }
 
   /**
@@ -1652,6 +1752,9 @@ export const countSummaryOps: Summary<CountSummary> = {
   },
   combine(left: CountSummary, right: CountSummary): CountSummary {
     return { count: left.count + right.count };
+  },
+  getItemCount(summary: CountSummary): number {
+    return summary.count;
   },
 };
 


### PR DESCRIPTION
## Summary

Implements `cursor.itemIndex()` by fixing the root cause of the `childIndex` dual semantics issue.

## Root Cause

The `childIndex` field in `StackEntry` served two conflicting purposes:
1. **Navigation bookmark**: After `findChildForTarget` descends into child `i`, it sets `childIndex = i + 1` so that `ascendAndContinue` resumes from the next child
2. **Position tracking**: Methods like `itemIndex()` and `recalculatePosition()` need to know which child we're actually inside (`i`, not `i + 1`)

The semantics differed between seek and walk paths:
- After `seekForward()`: internal nodes have `childIndex = i + 1` (exclusive)
- After `next()`: internal nodes have `childIndex = i` (inclusive)

## The Fix

Added an explicit `indexInParent` field to `StackEntry` that tracks which child of its parent each node is. This **separates navigation state from position tracking**, making the code unambiguous and correct regardless of how we reached the current position.

```typescript
interface StackEntry<D> {
  nodeId: NodeId;
  childIndex: number;      // Navigation state (unchanged semantics)
  indexInParent: number;   // Position tracking (new, unambiguous)
  position: D;
}
```

## Changes

**Data structure:**
- Add `indexInParent` field to `StackEntry` interface
- Add `getItemCount?(summary: S): number` to `Summary` interface for O(log n) efficiency

**Stack entry creation:**
- Update `descendToLeftmost()` / `descendToRightmost()` to accept and propagate `indexInParent`
- Update `findChildForTarget()` to set `indexInParent: i` when descending into child at index `i`
- Update all callers (`reset`, `advanceToNext`, `prev`) to pass correct `indexInParent`

**Position/index calculation:**
- Implement `itemIndex()` using `indexInParent` (O(log n) with `getItemCount`)
- Rewrite `recalculatePosition()` to use `indexInParent` for consistency
- Simplify `suffix()` to use `indexInParent` instead of nodeId matching

**API additions:**
- Add `countItemsInSubtree(nodeId)` to `SumTree` for fallback counting
- Add `getItemCount` to `countSummaryOps`

## Why This Is The Right Fix

The previous workaround (matching nodeIds to find which child we descended into) worked but:
- Added O(log n) extra work per internal level
- Left the underlying inconsistency in place
- Future code could still fall into the same trap

This fix makes the data structure self-documenting and unambiguous. Every stack entry knows exactly which child of its parent it is, regardless of navigation history.

## Test Plan

- [x] 55 sum-tree tests pass (including 13 new `itemIndex()` tests)
- [x] 120 text buffer tests pass
- [x] Walk vs seek consistency verified for single-leaf, multi-leaf, and deep trees
- [x] Edge cases tested: empty tree, single item, beginning/end positions
- [x] O(log n) performance verified with `getItemCount`

Fixes #107