### PR TITLE
fix(ci): simplify Pages workflow to deploy-only

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,14 +3,15 @@ name: Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'docs/bench/**'
   workflow_dispatch:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
-  contents: write
   pages: write
   id-token: write
 
@@ -23,56 +24,18 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Check if already recorded
-        id: check
-        run: |
-          SHA=$(git rev-parse HEAD)
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          if git cat-file -e "origin/benchmark-data:results/$SHA.json" 2>/dev/null; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Benchmarks already recorded for $SHA — skipping."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install dependencies
-        if: steps.check.outputs.skip != 'true'
-        run: bun install --frozen-lockfile
-
-      - name: Download editing trace
-        if: steps.check.outputs.skip != 'true'
-        run: bun run fixtures:download
-
-      - name: Record benchmarks
-        if: steps.check.outputs.skip != 'true'
-        run: bun run bench:record --push
 
       - name: Assemble Pages artifact
-        if: steps.check.outputs.skip != 'true'
         run: |
           git fetch origin benchmark-data
           git worktree add _site benchmark-data
           cp docs/bench/index.html _site/index.html
 
       - name: Upload Pages artifact
-        if: steps.check.outputs.skip != 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
 
       - name: Deploy to GitHub Pages
-        if: steps.check.outputs.skip != 'true'
         id: deploy
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Removes benchmark recording from Pages workflow (now in separate `benchmarks.yml`)
- Only triggers on `docs/bench/**` changes or manual dispatch
- Just assembles site from `benchmark-data` branch and deploys

## Test plan
- [ ] Manually trigger and verify Pages deploys