### PR TITLE
perf: use insertAtMut to eliminate O(n) Map copy in insert hot path

### DIFF
--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -751,9 +751,9 @@ export class TextBuffer {
         const locator = locatorBetween(fastResult.leftLocator, fastResult.rightLocator);
         const newFrag = createFragment(opId, 0, locator, text, true);
 
-        // O(log² n) to find index + O(log n) to insert
+        // O(log² n) to find index + O(log n) to insert (mutating - safe since no snapshots)
         const insertIdx = this.findTreeInsertIndex(newFrag);
-        this.fragments = this.fragments.insertAt(insertIdx, newFrag);
+        this.fragments.insertAtMut(insertIdx, newFrag);
         this.addToFragmentIndex(opId);
 
         return {
@@ -795,9 +795,9 @@ export class TextBuffer {
       }
       this.setFragments(frags);
     } else {
-      // No split and no snapshots: use direct tree insertion (O(log n))
+      // No split and no snapshots: use direct tree insertion (O(log n), mutating)
       const insertIdx = this.findTreeInsertIndex(newFrag);
-      this.fragments = this.fragments.insertAt(insertIdx, newFrag);
+      this.fragments.insertAtMut(insertIdx, newFrag);
       this.addToFragmentIndex(opId);
     }
 


### PR DESCRIPTION
## Summary

- Replace `insertAt()` (non-mutating) with `insertAtMut()` (in-place) in the two local insert fast paths that already verify no live snapshots exist
- The non-mutating `insertAt()` calls `shallowClone()` which copies the entire `summaries` Map (O(n)) on every insert, making sequential inserts O(n²)
- `insertAtMut()` modifies the tree in-place with O(log n) cost

## Benchmark Results

| Operation | Before | After | Speedup |
|-----------|--------|-------|---------|
| 10K inserts at start | 1827µs/op | 4µs/op | **~450x** |
| 50K inserts at start | O(n²) | 6.7µs/op | O(n log² n) |
| 10K inserts at end | 2.15µs/op | 1.78µs/op | 1.2x |

## Test plan

- [x] All existing tests pass (12 pre-existing failures in undo property tests and snapshot test are unchanged)
- [x] Verified both changed paths are guarded by `_liveSnapshots === 0`, making mutation safe
- [x] Profiled scaling behavior from 1K to 50K operations — per-op cost is now nearly flat (O(log² n))

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)