### PR TITLE
fix(ci): run Pages on every merge, skip if no new benchmark data

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,6 @@ name: Pages
 on:
   push:
     branches: [main]
-    paths:
-      - 'docs/bench/**'
   workflow_dispatch:
 
 concurrency:
@@ -12,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: write
   pages: write
   id-token: write
 
@@ -24,18 +23,44 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for new benchmark data
+        id: check
+        run: |
+          git fetch origin benchmark-data --tags
+          CURRENT=$(git rev-parse origin/benchmark-data)
+          DEPLOYED=$(git rev-parse pages-deployed 2>/dev/null || echo "none")
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "deployed=$DEPLOYED" >> "$GITHUB_OUTPUT"
+          if [ "$CURRENT" = "$DEPLOYED" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No new benchmark data since last deploy — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Assemble Pages artifact
+        if: steps.check.outputs.skip != 'true'
         run: |
           git fetch origin benchmark-data
           git worktree add _site benchmark-data
           cp docs/bench/index.html _site/index.html
 
       - name: Upload Pages artifact
+        if: steps.check.outputs.skip != 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
 
       - name: Deploy to GitHub Pages
+        if: steps.check.outputs.skip != 'true'
         id: deploy
         uses: actions/deploy-pages@v4
+
+      - name: Update deployed marker
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git tag -f pages-deployed ${{ steps.check.outputs.current }}
+          git push -f origin pages-deployed


### PR DESCRIPTION
## Summary
- Runs on every merge to main (removes incorrect paths filter)
- Checks if `benchmark-data` branch has new commits since last deploy
- Uses `pages-deployed` tag to track deployed state
- Skips entire deploy if no new benchmark data

## Test plan
- [ ] First run creates the `pages-deployed` tag and deploys
- [ ] Subsequent runs without new benchmark data skip with notice
- [ ] New benchmark data triggers deploy and updates tag