### PR TITLE
fix(ci): handle missing pages-deployed tag

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,11 @@ jobs:
         run: |
           git fetch origin benchmark-data --tags
           CURRENT=$(git rev-parse origin/benchmark-data)
-          DEPLOYED=$(git rev-parse pages-deployed 2>/dev/null || echo "none")
+          if git rev-parse pages-deployed >/dev/null 2>&1; then
+            DEPLOYED=$(git rev-parse pages-deployed)
+          else
+            DEPLOYED="none"
+          fi
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "deployed=$DEPLOYED" >> "$GITHUB_OUTPUT"
           if [ "$CURRENT" = "$DEPLOYED" ]; then


### PR DESCRIPTION
## Summary
Fix the tag check to properly handle when `pages-deployed` tag doesn't exist yet.

The previous approach `$(git rev-parse pages-deployed 2>/dev/null || echo "none")` wasn't working correctly in GitHub Actions.

## Test plan
- [ ] First run (no tag exists) should deploy and create tag