### PR TITLE
fix: fetch remote benchmark-data before creating worktree

### DIFF
--- a/scripts/record-benchmarks.ts
+++ b/scripts/record-benchmarks.ts
@@ -211,8 +211,24 @@ function runBenchmarks(): SlimResults | { raw: string } {
 }
 
 function ensureOrphanBranch(worktree: string) {
-  // Check if branch exists
+  // Fetch remote branch first to ensure we have latest
   try {
+    exec(`git fetch origin ${BRANCH}`);
+  } catch {
+    // Remote branch may not exist yet
+  }
+
+  // Check if branch exists (prefer remote-tracking branch for freshness)
+  try {
+    // Try remote-tracking branch first (most up-to-date)
+    try {
+      exec(`git rev-parse --verify origin/${BRANCH}`);
+      exec(`git worktree add "${worktree}" origin/${BRANCH}`);
+      exec(`git checkout -B ${BRANCH}`, { cwd: worktree });
+      return;
+    } catch {
+      // Fall back to local branch
+    }
     exec(`git rev-parse --verify ${BRANCH}`);
     // Branch exists, clone it to worktree
     exec(`git worktree add "${worktree}" ${BRANCH}`);


### PR DESCRIPTION
## Summary

Fixes benchmark recording failures when the remote `benchmark-data` branch is ahead of local.

The script was creating a worktree from the local branch reference, then trying to fetch/rebase after committing. This caused non-fast-forward push failures when another benchmark had been recorded since the last fetch.

Now fetches `origin/benchmark-data` first and creates the worktree from the remote-tracking branch.

## Test plan

- [ ] Re-run benchmark workflow with `force=true` after merge