### PR TITLE
perf: fix redistributeNodes and enable O(log n) incremental splits

### DIFF
--- a/src/sum-tree/index.test.ts
+++ b/src/sum-tree/index.test.ts
@@ -320,6 +320,33 @@ describe("SumTree", () => {
       expect(invariants.valid).toBe(true);
     });
 
+    it("preserves item order when redistributing with right sibling (BF=4)", () => {
+      // Regression test: redistributeNodes leaf case previously used
+      // total.reverse() which scrambled individual item order when the
+      // sibling was to the right. The fix uses conditional spread order
+      // matching the internal-node pattern.
+      let tree = new SumTree<CountItem, CountSummary>(countSummaryOps, 4);
+
+      // Build a tree that will trigger right-sibling redistribution on delete
+      for (let i = 0; i < 16; i++) {
+        tree = tree.push(new CountItem(i));
+      }
+
+      // Delete from the left to trigger redistribution with a right sibling
+      for (let i = 0; i < 8; i++) {
+        tree = tree.removeAt(0);
+        const arr = tree.toArray().map((x) => x.value);
+        // Items should remain in ascending order
+        for (let j = 1; j < arr.length; j++) {
+          expect(arr[j]).toBeGreaterThan(arr[j - 1] as number);
+        }
+        const invariants = tree.checkInvariants();
+        expect(invariants.valid).toBe(true);
+      }
+
+      expect(tree.toArray().map((x) => x.value)).toEqual([8, 9, 10, 11, 12, 13, 14, 15]);
+    });
+
     it("maintains all leaves at same depth", () => {
       let tree = new SumTree<CountItem, CountSummary>(countSummaryOps, 4);
 

--- a/src/sum-tree/index.ts
+++ b/src/sum-tree/index.ts
@@ -1882,10 +1882,9 @@ export class SumTree<T extends Summarizable<S>, S> {
       const nodeItems = nodeData?.items ?? [];
       const siblingItems = siblingData?.items ?? [];
 
-      const total = [...siblingItems, ...nodeItems];
-      if (!siblingIsLeft) {
-        total.reverse();
-      }
+      const total = siblingIsLeft
+        ? [...siblingItems, ...nodeItems]
+        : [...nodeItems, ...siblingItems];
 
       const mid = Math.floor(total.length / 2);
       const leftItems = total.slice(0, mid);

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -1446,23 +1446,14 @@ export class TextBuffer {
       this.fragments.insertAtMut(insertIndex, newFrag);
       this.addToFragmentIndex(op.id);
     } else if (this._liveSnapshots === 0) {
-      // Splits needed: use array for splits, then direct tree insertion
-      // NOTE: Incremental tree splits were attempted but SumTree.removeAt() has bugs
-      // that corrupt the tree structure. Using array-based approach for now.
-      const frags = this.fragmentsArray();
-
+      // Splits needed: use O(log n) tree operations directly
       if (needsAfterSplit) {
-        this.findRefIndex(frags, op.after, "after");
+        this.splitRefInTree(op.after, "after");
       }
       if (needsBeforeSplit) {
-        this.findRefIndex(frags, op.before, "before");
+        this.splitRefInTree(op.before, "before");
       }
 
-      // After splits, re-sort and rebuild tree, then use direct insertion
-      sortFragments(frags);
-      this.setFragments(frags);
-
-      // Now use O(log² n) insertion for the new fragment
       const insertIndex = this.findTreeInsertIndex(newFrag);
       this.fragments.insertAtMut(insertIndex, newFrag);
       this.addToFragmentIndex(op.id);
@@ -1684,12 +1675,6 @@ export class TextBuffer {
    * modifying the array, sorting, and rebuilding the tree (O(n)), we find
    * the fragment that needs splitting and modify the tree directly.
    *
-   * BLOCKING ISSUE: SumTree.removeAt() has bugs that corrupt the tree structure
-   * during rebalancing (mergeOrRedistribute). Until this is fixed, we must use
-   * the array-based approach in findRefIndex + sortFragments + setFragments.
-   *
-   * See: https://github.com/iamnbutler/crdt/issues/158
-   *
    * @returns true if a split was performed, false if no split was needed
    *          (either exact match found or reference not found)
    */
@@ -1733,8 +1718,6 @@ export class TextBuffer {
         const splitPoint = ref.offset - frag.insertionOffset;
         const [leftPart, rightPart] = splitFragment(frag, splitPoint);
 
-        // NOTE: This approach is currently broken due to SumTree.removeAt() bugs.
-        // See the array-based approach in applyRemoteInsertDirect instead.
         this.fragments = this.fragments.removeAt(index);
 
         const leftIdx = this.findTreeInsertIndex(leftPart);


### PR DESCRIPTION
## Summary

- **Fix SumTree `redistributeNodes` leaf case**: The leaf branch used `total.reverse()` which scrambled individual item order when redistributing with a right sibling. Changed to conditional spread order (`siblingIsLeft ? [...sibling, ...node] : [...node, ...sibling]`), matching the existing internal-node pattern.
- **Enable O(log n) `splitRefInTree` path**: With the bug fixed, `applyRemoteInsertDirect` now uses incremental tree operations (`removeAt` + `insertAtMut`) for fragment splits instead of the O(n) fallback that extracted all fragments to an array, sorted, and rebuilt the tree.
- **Add regression test**: Targeted test with BF=4 that reproducibly triggers right-sibling redistribution and verifies item order is preserved.

Closes #158, addresses performance backlog items from #161.

## Test plan

- [x] All 3967 tests pass (3966 existing + 1 new regression test)
- [x] TypeScript typechecks clean
- [x] Performance tests still within targets (10K inserts: 38ms, 1K remote ops: 22ms)
- [ ] Verify no regressions in property-based convergence tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)