### PR TITLE
perf: enable O(log n) incremental splits for remote inserts

### DIFF
--- a/src/sum-tree/index.test.ts
+++ b/src/sum-tree/index.test.ts
@@ -320,6 +320,49 @@ describe("SumTree", () => {
       expect(invariants.valid).toBe(true);
     });
 
+    it("preserves order when redistribution uses a right sibling", () => {
+      // Regression test: removing items from the left leaf should trigger
+      // redistribution with the right sibling without scrambling item order.
+      // The bug was in redistributeNodes using total.reverse() instead of
+      // correct concatenation order for the !siblingIsLeft case.
+      let tree = new SumTree<CountItem, CountSummary>(countSummaryOps, 4);
+
+      // Create 8 items → two full leaves: [0,1,2,3] | [4,5,6,7]
+      for (let i = 0; i < 8; i++) {
+        tree = tree.push(new CountItem(i));
+      }
+
+      // Remove first 3 items → left leaf underflows to [3], triggers right-sibling redistribution
+      tree = tree.removeAt(0); // remove 0
+      tree = tree.removeAt(0); // remove 1
+      tree = tree.removeAt(0); // remove 2
+
+      expect(tree.length()).toBe(5);
+      expect(tree.toArray().map((i) => i.value)).toEqual([3, 4, 5, 6, 7]);
+
+      const invariants = tree.checkInvariants();
+      expect(invariants.valid).toBe(true);
+    });
+
+    it("preserves order when replaceAtMut removes triggering redistribution", () => {
+      // Same scenario but using replaceAtMut(index, []) for removal
+      const tree = new SumTree<CountItem, CountSummary>(countSummaryOps, 4);
+
+      for (let i = 0; i < 8; i++) {
+        tree.pushMut(new CountItem(i));
+      }
+
+      tree.replaceAtMut(0, []);
+      tree.replaceAtMut(0, []);
+      tree.replaceAtMut(0, []);
+
+      expect(tree.length()).toBe(5);
+      expect(tree.toArray().map((i) => i.value)).toEqual([3, 4, 5, 6, 7]);
+
+      const invariants = tree.checkInvariants();
+      expect(invariants.valid).toBe(true);
+    });
+
     it("maintains all leaves at same depth", () => {
       let tree = new SumTree<CountItem, CountSummary>(countSummaryOps, 4);
 

--- a/src/sum-tree/index.ts
+++ b/src/sum-tree/index.ts
@@ -1882,10 +1882,9 @@ export class SumTree<T extends Summarizable<S>, S> {
       const nodeItems = nodeData?.items ?? [];
       const siblingItems = siblingData?.items ?? [];
 
-      const total = [...siblingItems, ...nodeItems];
-      if (!siblingIsLeft) {
-        total.reverse();
-      }
+      const total = siblingIsLeft
+        ? [...siblingItems, ...nodeItems]
+        : [...nodeItems, ...siblingItems];
 
       const mid = Math.floor(total.length / 2);
       const leftItems = total.slice(0, mid);

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -1446,23 +1446,15 @@ export class TextBuffer {
       this.fragments.insertAtMut(insertIndex, newFrag);
       this.addToFragmentIndex(op.id);
     } else if (this._liveSnapshots === 0) {
-      // Splits needed: use array for splits, then direct tree insertion
-      // NOTE: Incremental tree splits were attempted but SumTree.removeAt() has bugs
-      // that corrupt the tree structure. Using array-based approach for now.
-      const frags = this.fragmentsArray();
-
+      // Splits needed: use O(log n) incremental tree splits
       if (needsAfterSplit) {
-        this.findRefIndex(frags, op.after, "after");
+        this.splitRefInTree(op.after, "after");
       }
       if (needsBeforeSplit) {
-        this.findRefIndex(frags, op.before, "before");
+        this.splitRefInTree(op.before, "before");
       }
 
-      // After splits, re-sort and rebuild tree, then use direct insertion
-      sortFragments(frags);
-      this.setFragments(frags);
-
-      // Now use O(log² n) insertion for the new fragment
+      // Use O(log² n) insertion for the new fragment
       const insertIndex = this.findTreeInsertIndex(newFrag);
       this.fragments.insertAtMut(insertIndex, newFrag);
       this.addToFragmentIndex(op.id);
@@ -1675,20 +1667,9 @@ export class TextBuffer {
   }
 
   /**
-   * [EXPERIMENTAL - NOT CURRENTLY USED]
-   *
    * Incrementally split a fragment in the tree to satisfy a reference.
-   * Uses O(log n) cursor iteration + O(log² n) insertions = O(log² n) total.
-   *
-   * This would be the key optimization: instead of extracting all fragments,
-   * modifying the array, sorting, and rebuilding the tree (O(n)), we find
-   * the fragment that needs splitting and modify the tree directly.
-   *
-   * BLOCKING ISSUE: SumTree.removeAt() has bugs that corrupt the tree structure
-   * during rebalancing (mergeOrRedistribute). Until this is fixed, we must use
-   * the array-based approach in findRefIndex + sortFragments + setFragments.
-   *
-   * See: https://github.com/iamnbutler/crdt/issues/158
+   * Uses cursor iteration to find the fragment, then O(log n) tree operations
+   * for the split — avoiding O(n) extract + sort + rebuild.
    *
    * @returns true if a split was performed, false if no split was needed
    *          (either exact match found or reference not found)
@@ -1733,9 +1714,8 @@ export class TextBuffer {
         const splitPoint = ref.offset - frag.insertionOffset;
         const [leftPart, rightPart] = splitFragment(frag, splitPoint);
 
-        // NOTE: This approach is currently broken due to SumTree.removeAt() bugs.
-        // See the array-based approach in applyRemoteInsertDirect instead.
-        this.fragments = this.fragments.removeAt(index);
+        // Remove original and insert split parts at their sorted positions
+        this.fragments.replaceAtMut(index, []);
 
         const leftIdx = this.findTreeInsertIndex(leftPart);
         this.fragments.insertAtMut(leftIdx, leftPart);
@@ -1767,7 +1747,7 @@ export class TextBuffer {
       if (matchFrag.insertionOffset === ref.offset && matchFrag.length > 0) {
         // Create zero-length left split to match sender state
         const [leftPart, rightPart] = splitFragment(matchFrag, 0);
-        this.fragments = this.fragments.removeAt(matchIndex);
+        this.fragments.replaceAtMut(matchIndex, []);
         const leftIdx = this.findTreeInsertIndex(leftPart);
         this.fragments.insertAtMut(leftIdx, leftPart);
         const rightIdx = this.findTreeInsertIndex(rightPart);
@@ -1782,7 +1762,7 @@ export class TextBuffer {
       if (matchFragEnd === ref.offset && matchFrag.length > 0) {
         // Create zero-length right split to match sender state
         const [leftPart, rightPart] = splitFragment(matchFrag, matchFrag.length);
-        this.fragments = this.fragments.removeAt(matchIndex);
+        this.fragments.replaceAtMut(matchIndex, []);
         const leftIdx = this.findTreeInsertIndex(leftPart);
         this.fragments.insertAtMut(leftIdx, leftPart);
         const rightIdx = this.findTreeInsertIndex(rightPart);


### PR DESCRIPTION
## Summary

- **Fix SumTree `redistributeNodes` bug**: Leaf redistribution with a right sibling used `total.reverse()` which scrambled item order. Fixed to use correct concatenation order (matching the internal-node case).
- **Enable `splitRefInTree`**: Wire the incremental tree-based split into `applyRemoteInsertDirect`, replacing the O(n) `fragmentsArray()` + `sortFragments()` + `setFragments()` rebuild cycle with O(log n) cursor find + mutable tree operations.
- **Add regression tests**: Two new SumTree tests covering right-sibling redistribution for both `removeAt` and `replaceAtMut`.

## Performance

1K remote ops benchmark: **65ms → ~20ms** (3.25x faster)

## Test plan

- [x] All 3968 tests pass (3966 existing + 2 new regression tests)
- [x] Property test seeds 54 and 490 pass (previously identified as convergence-failure seeds)
- [x] TypeScript typecheck passes
- [x] Pre-existing lint issues in `scripts/record-benchmarks.ts` are unrelated

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)