### PR TITLE
test: computeTextSummary edge cases and distributed undo/convergence tests

### DIFF
--- a/src/rope/summary.test.ts
+++ b/src/rope/summary.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test";
+import { byteLength, computeTextSummary, textSummaryOps } from "./summary.js";
+
+// ---------------------------------------------------------------------------
+// computeTextSummary: edge cases
+// ---------------------------------------------------------------------------
+
+describe("computeTextSummary edge cases", () => {
+  it("empty string produces zero summary", () => {
+    const s = computeTextSummary("");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(0);
+    expect(s.bytes).toBe(0);
+    expect(s.lastLineLen).toBe(0);
+    expect(s.lastLineBytes).toBe(0);
+  });
+
+  it("single newline produces one line with empty last line", () => {
+    const s = computeTextSummary("\n");
+    expect(s.lines).toBe(1);
+    expect(s.utf16Len).toBe(1);
+    expect(s.lastLineLen).toBe(0);
+    expect(s.lastLineBytes).toBe(0);
+  });
+
+  it("multiple consecutive newlines count each line", () => {
+    const s = computeTextSummary("\n\n\n");
+    expect(s.lines).toBe(3);
+    expect(s.utf16Len).toBe(3);
+    expect(s.lastLineLen).toBe(0);
+    expect(s.lastLineBytes).toBe(0);
+  });
+
+  it("text ending with newline has zero lastLineLen", () => {
+    const s = computeTextSummary("hello\n");
+    expect(s.lines).toBe(1);
+    expect(s.utf16Len).toBe(6);
+    expect(s.lastLineLen).toBe(0);
+    expect(s.lastLineBytes).toBe(0);
+  });
+
+  it("text not ending with newline has nonzero lastLineLen", () => {
+    const s = computeTextSummary("hello\nworld");
+    expect(s.lines).toBe(1);
+    expect(s.utf16Len).toBe(11);
+    expect(s.lastLineLen).toBe(5);
+    expect(s.lastLineBytes).toBe(5);
+  });
+
+  it("CRLF is not specially handled (\\r remains in last line)", () => {
+    // computeTextSummary only counts \n as line breaks.
+    // \r is treated as a regular character. The CRDT normalizes
+    // line endings upstream before text reaches this function.
+    const s = computeTextSummary("abc\r\ndef");
+    expect(s.lines).toBe(1); // only one \n
+    expect(s.utf16Len).toBe(8); // a,b,c,\r,\n,d,e,f
+    expect(s.lastLineLen).toBe(3); // "def"
+    expect(s.lastLineBytes).toBe(3);
+  });
+
+  it("lone \\r does not count as a line break", () => {
+    const s = computeTextSummary("abc\rdef");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(7);
+    expect(s.lastLineLen).toBe(7); // entire string is "last line"
+  });
+
+  it("handles multi-byte UTF-8 characters correctly", () => {
+    // "你好" = 2 chars, 6 bytes in UTF-8
+    const s = computeTextSummary("你好");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(2);
+    expect(s.bytes).toBe(6);
+    expect(s.lastLineLen).toBe(2);
+    expect(s.lastLineBytes).toBe(6);
+  });
+
+  it("handles emoji (surrogate pairs) correctly", () => {
+    // "😀" is a surrogate pair: 2 UTF-16 code units, 4 UTF-8 bytes
+    const s = computeTextSummary("😀");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(2); // surrogate pair
+    expect(s.bytes).toBe(4);
+    expect(s.lastLineLen).toBe(2);
+    expect(s.lastLineBytes).toBe(4);
+  });
+
+  it("multi-byte characters on last line after newline", () => {
+    const s = computeTextSummary("hello\n你好世界");
+    expect(s.lines).toBe(1);
+    expect(s.lastLineLen).toBe(4); // 4 CJK chars
+    expect(s.lastLineBytes).toBe(12); // 4 × 3 bytes
+  });
+
+  it("emoji after newline on last line", () => {
+    const s = computeTextSummary("line1\n😀😀");
+    expect(s.lines).toBe(1);
+    expect(s.lastLineLen).toBe(4); // 2 emojis × 2 code units
+    expect(s.lastLineBytes).toBe(8); // 2 emojis × 4 bytes
+  });
+
+  it("many empty lines (only newlines)", () => {
+    const text = "\n".repeat(100);
+    const s = computeTextSummary(text);
+    expect(s.lines).toBe(100);
+    expect(s.utf16Len).toBe(100);
+    expect(s.lastLineLen).toBe(0);
+  });
+
+  it("single character without newline", () => {
+    const s = computeTextSummary("x");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(1);
+    expect(s.bytes).toBe(1);
+    expect(s.lastLineLen).toBe(1);
+    expect(s.lastLineBytes).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// byteLength edge cases
+// ---------------------------------------------------------------------------
+
+describe("byteLength", () => {
+  it("empty string is 0 bytes", () => {
+    expect(byteLength("")).toBe(0);
+  });
+
+  it("ASCII is 1 byte per char", () => {
+    expect(byteLength("hello")).toBe(5);
+  });
+
+  it("2-byte UTF-8 (Latin extended)", () => {
+    // "ñ" (U+00F1) is 2 bytes in UTF-8
+    expect(byteLength("ñ")).toBe(2);
+  });
+
+  it("3-byte UTF-8 (CJK)", () => {
+    // "你" (U+4F60) is 3 bytes in UTF-8
+    expect(byteLength("你")).toBe(3);
+  });
+
+  it("4-byte UTF-8 (emoji)", () => {
+    // "😀" (U+1F600) is 4 bytes in UTF-8
+    expect(byteLength("😀")).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// textSummaryOps.combine: edge cases
+// ---------------------------------------------------------------------------
+
+describe("textSummaryOps.combine edge cases", () => {
+  it("combining two empty-line chunks", () => {
+    const left = computeTextSummary("\n");
+    const right = computeTextSummary("\n");
+    const combined = textSummaryOps.combine(left, right);
+    expect(combined.lines).toBe(2);
+    expect(combined.utf16Len).toBe(2);
+    expect(combined.lastLineLen).toBe(0);
+  });
+
+  it("combining text with trailing newline + empty string", () => {
+    const left = computeTextSummary("abc\n");
+    const right = computeTextSummary("");
+    const combined = textSummaryOps.combine(left, right);
+    expect(combined.lines).toBe(1);
+    expect(combined.utf16Len).toBe(4);
+    expect(combined.lastLineLen).toBe(0);
+  });
+
+  it("combining empty string + text with leading newline", () => {
+    const left = computeTextSummary("");
+    const right = computeTextSummary("\nabc");
+    const combined = textSummaryOps.combine(left, right);
+    expect(combined.lines).toBe(1);
+    expect(combined.utf16Len).toBe(4);
+    expect(combined.lastLineLen).toBe(3);
+  });
+
+  it("combining preserves bytes across multi-byte boundaries", () => {
+    const left = computeTextSummary("你好\n");
+    const right = computeTextSummary("世界");
+    const combined = textSummaryOps.combine(left, right);
+    expect(combined.lines).toBe(1);
+    expect(combined.bytes).toBe(13); // 4 CJK × 3 bytes + 1 newline
+    expect(combined.lastLineBytes).toBe(6); // "世界" = 6 bytes
+  });
+
+  it("4-way associativity with multi-byte and newlines", () => {
+    const a = computeTextSummary("你\n");
+    const b = computeTextSummary("好");
+    const c = computeTextSummary("\n世");
+    const d = computeTextSummary("界\n");
+
+    const ab = textSummaryOps.combine(a, b);
+    const cd = textSummaryOps.combine(c, d);
+    const abcd = textSummaryOps.combine(ab, cd);
+
+    const bc = textSummaryOps.combine(b, c);
+    const abc = textSummaryOps.combine(a, bc);
+    const abcd2 = textSummaryOps.combine(abc, d);
+
+    expect(abcd).toEqual(abcd2);
+    expect(abcd.lines).toBe(3);
+  });
+});

--- a/src/text/distributed-undo.test.ts
+++ b/src/text/distributed-undo.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "bun:test";
+import { TextBuffer } from "./text-buffer.js";
+import { replicaId } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Distributed undo/redo: undo operations with interleaved remote ops
+// ---------------------------------------------------------------------------
+
+describe("Distributed undo with remote operations", () => {
+  it("undo on replica 1 propagates to replica 2", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+
+    // Replica 1 inserts text
+    const insertOp = buf1.insert(0, "Hello");
+    buf2.applyRemote(insertOp);
+
+    expect(buf1.getText()).toBe("Hello");
+    expect(buf2.getText()).toBe("Hello");
+
+    // Replica 1 undoes the insert
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    expect(buf1.getText()).toBe("");
+
+    // Propagate undo to replica 2
+    if (undoOp !== null) {
+      buf2.applyRemote(undoOp);
+    }
+    expect(buf2.getText()).toBe("");
+  });
+
+  it("undo + redo propagation converges", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+
+    const insertOp = buf1.insert(0, "Hello");
+    buf2.applyRemote(insertOp);
+
+    // Undo on replica 1
+    const undoOp = buf1.undo();
+    if (undoOp !== null) buf2.applyRemote(undoOp);
+    expect(buf1.getText()).toBe("");
+    expect(buf2.getText()).toBe("");
+
+    // Redo on replica 1
+    const redoOp = buf1.redo();
+    if (redoOp !== null) buf2.applyRemote(redoOp);
+    expect(buf1.getText()).toBe("Hello");
+    expect(buf2.getText()).toBe("Hello");
+  });
+
+  it("undo after receiving remote insert preserves remote text", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+
+    // Replica 1 inserts "Hello"
+    const op1 = buf1.insert(0, "Hello");
+    buf2.applyRemote(op1);
+
+    // Replica 2 inserts " World" at the end
+    const op2 = buf2.insert(5, " World");
+    buf1.applyRemote(op2);
+
+    expect(buf1.getText()).toBe("Hello World");
+    expect(buf2.getText()).toBe("Hello World");
+
+    // Replica 1 undoes its own insert ("Hello"), but " World" from replica 2 survives
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    expect(buf1.getText()).toBe(" World");
+
+    // Propagate undo to replica 2
+    if (undoOp !== null) buf2.applyRemote(undoOp);
+    expect(buf2.getText()).toBe(" World");
+  });
+
+  it("concurrent undo on both replicas converges", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+
+    // Use time source to separate transactions
+    let time1 = 0;
+    let time2 = 0;
+    const buf1 = TextBuffer.create(rid1);
+    buf1.setTimeSource(() => time1);
+    const buf2 = TextBuffer.create(rid2);
+    buf2.setTimeSource(() => time2);
+
+    // Both start with shared text (own transaction)
+    const initOp = buf1.insert(0, "ABCD");
+    buf2.applyRemote(initOp);
+
+    // Advance time to separate transactions
+    time1 += 500;
+    time2 += 500;
+
+    // Each replica inserts its own text (separate transaction from init)
+    const op1 = buf1.insert(4, "EF");
+    const op2 = buf2.insert(4, "GH");
+
+    // Sync the inserts
+    buf1.applyRemote(op2);
+    buf2.applyRemote(op1);
+
+    const text = buf1.getText();
+    expect(text).toBe(buf2.getText());
+
+    // Each replica undoes its own most recent insert
+    const undo1 = buf1.undo(); // undoes "EF"
+    const undo2 = buf2.undo(); // undoes "GH"
+
+    // Cross-apply undos
+    if (undo1 !== null) buf2.applyRemote(undo1);
+    if (undo2 !== null) buf1.applyRemote(undo2);
+
+    // Both should converge to just the initial "ABCD"
+    expect(buf1.getText()).toBe(buf2.getText());
+    expect(buf1.getText()).toBe("ABCD");
+  });
+
+  it("undo of delete restores text on remote replica", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+
+    // Shared initial state
+    const initOp = buf1.insert(0, "Hello World");
+    buf2.applyRemote(initOp);
+
+    // Replica 1 deletes "World"
+    const deleteOp = buf1.delete(6, 11);
+    buf2.applyRemote(deleteOp);
+    expect(buf1.getText()).toBe("Hello ");
+    expect(buf2.getText()).toBe("Hello ");
+
+    // Replica 1 undoes the delete
+    const undoOp = buf1.undo();
+    expect(buf1.getText()).toBe("Hello World");
+
+    // Propagate undo to replica 2
+    if (undoOp !== null) buf2.applyRemote(undoOp);
+    expect(buf2.getText()).toBe("Hello World");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Three-replica convergence
+// ---------------------------------------------------------------------------
+
+describe("Three-replica convergence", () => {
+  it("three concurrent inserts at same position converge", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+    const rid3 = replicaId(3);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+    const buf3 = TextBuffer.create(rid3);
+
+    // Each replica inserts different text at position 0
+    const op1 = buf1.insert(0, "A");
+    const op2 = buf2.insert(0, "B");
+    const op3 = buf3.insert(0, "C");
+
+    // Full sync: each replica receives the other two ops
+    buf1.applyRemote(op2);
+    buf1.applyRemote(op3);
+    buf2.applyRemote(op1);
+    buf2.applyRemote(op3);
+    buf3.applyRemote(op1);
+    buf3.applyRemote(op2);
+
+    // All three must converge to the same text
+    const text = buf1.getText();
+    expect(buf2.getText()).toBe(text);
+    expect(buf3.getText()).toBe(text);
+
+    // Must contain all three characters
+    expect(text).toContain("A");
+    expect(text).toContain("B");
+    expect(text).toContain("C");
+    expect(text.length).toBe(3);
+  });
+
+  it("three replicas with inserts and deletes converge", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+    const rid3 = replicaId(3);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+    const buf3 = TextBuffer.create(rid3);
+
+    // Replica 1 creates initial text
+    const initOp = buf1.insert(0, "ABCDE");
+    buf2.applyRemote(initOp);
+    buf3.applyRemote(initOp);
+
+    // Concurrent operations:
+    // Replica 1: insert "X" at position 2
+    const op1 = buf1.insert(2, "X");
+    // Replica 2: delete "CD" (positions 2-4)
+    const op2 = buf2.delete(2, 4);
+    // Replica 3: insert "Y" at position 4
+    const op3 = buf3.insert(4, "Y");
+
+    // Full sync
+    buf1.applyRemote(op2);
+    buf1.applyRemote(op3);
+    buf2.applyRemote(op1);
+    buf2.applyRemote(op3);
+    buf3.applyRemote(op1);
+    buf3.applyRemote(op2);
+
+    // All must converge
+    const text = buf1.getText();
+    expect(buf2.getText()).toBe(text);
+    expect(buf3.getText()).toBe(text);
+
+    // "X" and "Y" should survive (different insertions)
+    // "CD" should be deleted
+    expect(text).toContain("X");
+    expect(text).toContain("Y");
+    expect(text).not.toContain("C");
+    expect(text).not.toContain("D");
+  });
+
+  it("three replicas with different operation ordering converge", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+    const rid3 = replicaId(3);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+    const buf3 = TextBuffer.create(rid3);
+
+    // Shared initial state
+    const initOp = buf1.insert(0, "Hello");
+    buf2.applyRemote(initOp);
+    buf3.applyRemote(initOp);
+
+    // Concurrent inserts
+    const op1 = buf1.insert(5, " World");
+    const op2 = buf2.insert(0, "Say: ");
+    const op3 = buf3.insert(5, "!");
+
+    // Apply in DIFFERENT orders to each replica
+    buf1.applyRemote(op3);
+    buf1.applyRemote(op2);
+
+    buf2.applyRemote(op1);
+    buf2.applyRemote(op3);
+
+    buf3.applyRemote(op2);
+    buf3.applyRemote(op1);
+
+    // Must converge regardless of application order
+    const text = buf1.getText();
+    expect(buf2.getText()).toBe(text);
+    expect(buf3.getText()).toBe(text);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot isolation with concurrent mutations
+// ---------------------------------------------------------------------------
+
+describe("Snapshot isolation under mutations", () => {
+  it("snapshot is not affected by subsequent inserts and deletes", () => {
+    const buf = TextBuffer.fromString("Initial");
+    const snap = buf.snapshot();
+
+    // Mutate the buffer heavily
+    buf.insert(7, " text");
+    buf.delete(0, 7);
+    buf.insert(0, "New");
+
+    // Snapshot still sees original
+    expect(snap.getText()).toBe("Initial");
+    expect(snap.length).toBe(7);
+
+    snap.release();
+  });
+
+  it("multiple snapshots capture different states", () => {
+    const buf = TextBuffer.create();
+
+    buf.insert(0, "A");
+    const snap1 = buf.snapshot();
+
+    buf.insert(1, "B");
+    const snap2 = buf.snapshot();
+
+    buf.insert(2, "C");
+    const snap3 = buf.snapshot();
+
+    expect(snap1.getText()).toBe("A");
+    expect(snap2.getText()).toBe("AB");
+    expect(snap3.getText()).toBe("ABC");
+
+    snap1.release();
+    snap2.release();
+    snap3.release();
+  });
+
+  it("snapshot survives undo/redo on the live buffer", () => {
+    let time = 0;
+    const buf = TextBuffer.create();
+    buf.setTimeSource(() => time);
+
+    buf.insert(0, "Hello");
+    time += 500; // separate transaction
+    const snap = buf.snapshot();
+
+    buf.insert(5, " World");
+    buf.undo(); // undoes " World" only
+    buf.redo(); // redoes " World"
+    buf.undo(); // undoes " World" again
+
+    // Snapshot is frozen at "Hello"
+    expect(snap.getText()).toBe("Hello");
+    expect(buf.getText()).toBe("Hello");
+
+    snap.release();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 34 new tests across 2 new test files covering previously untested areas identified by the Daily Test Improver (#163)
- `src/rope/summary.test.ts`: 20 tests for `computeTextSummary` edge cases (CRLF, empty lines, multi-byte UTF-8, emoji/surrogate pairs, byte lengths) and `textSummaryOps.combine` boundary conditions
- `src/text/distributed-undo.test.ts`: 14 tests for distributed undo/redo propagation, three-replica convergence, and snapshot isolation under mutations

## Test plan

- [x] All 34 new tests pass
- [x] Full test suite passes (497 tests, 0 failures)
- [x] Lint clean
- [x] No type errors introduced (pre-existing tsconfig deprecation warning only)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)