### PR TITLE
test: computeTextSummary edge cases and distributed undo/convergence tests

### DIFF
--- a/src/rope/summary.test.ts
+++ b/src/rope/summary.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "bun:test";
+import { textSummaryOps } from "../sum-tree/index.js";
+import { byteLength, computeTextSummary } from "./summary.js";
+
+// ---------------------------------------------------------------------------
+// byteLength
+// ---------------------------------------------------------------------------
+
+describe("byteLength", () => {
+  it("empty string", () => {
+    expect(byteLength("")).toBe(0);
+  });
+
+  it("ASCII string", () => {
+    expect(byteLength("hello")).toBe(5);
+  });
+
+  it("multi-byte UTF-8 (CJK)", () => {
+    // Each CJK character is 3 bytes in UTF-8
+    expect(byteLength("你好")).toBe(6);
+  });
+
+  it("emoji (4-byte UTF-8)", () => {
+    // 🎉 is U+1F389, 4 bytes in UTF-8
+    expect(byteLength("🎉")).toBe(4);
+  });
+
+  it("mixed ASCII and multi-byte", () => {
+    // "a" = 1 byte, "é" = 2 bytes, "你" = 3 bytes, "🎉" = 4 bytes
+    expect(byteLength("aé你🎉")).toBe(1 + 2 + 3 + 4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTextSummary
+// ---------------------------------------------------------------------------
+
+describe("computeTextSummary", () => {
+  it("empty string", () => {
+    const s = computeTextSummary("");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(0);
+    expect(s.bytes).toBe(0);
+    expect(s.lastLineLen).toBe(0);
+    expect(s.lastLineBytes).toBe(0);
+  });
+
+  it("single newline", () => {
+    const s = computeTextSummary("\n");
+    expect(s.lines).toBe(1);
+    expect(s.utf16Len).toBe(1);
+    expect(s.bytes).toBe(1);
+    expect(s.lastLineLen).toBe(0);
+    expect(s.lastLineBytes).toBe(0);
+  });
+
+  it("multiple consecutive newlines", () => {
+    const s = computeTextSummary("\n\n\n");
+    expect(s.lines).toBe(3);
+    expect(s.utf16Len).toBe(3);
+    expect(s.lastLineLen).toBe(0);
+  });
+
+  it("text without trailing newline", () => {
+    const s = computeTextSummary("abc");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(3);
+    expect(s.bytes).toBe(3);
+    expect(s.lastLineLen).toBe(3);
+    expect(s.lastLineBytes).toBe(3);
+  });
+
+  it("text with trailing newline", () => {
+    const s = computeTextSummary("abc\n");
+    expect(s.lines).toBe(1);
+    expect(s.utf16Len).toBe(4);
+    expect(s.lastLineLen).toBe(0);
+    expect(s.lastLineBytes).toBe(0);
+  });
+
+  it("multiple lines with content", () => {
+    const s = computeTextSummary("abc\ndef\nghi");
+    expect(s.lines).toBe(2);
+    expect(s.utf16Len).toBe(11);
+    expect(s.lastLineLen).toBe(3);
+    expect(s.lastLineBytes).toBe(3);
+  });
+
+  // CRLF handling: computeTextSummary only counts \n as line breaks.
+  // The CRDT normalizes line endings upstream.
+  it("CRLF: \\r\\n counts as one line (only \\n counted)", () => {
+    const s = computeTextSummary("abc\r\ndef");
+    expect(s.lines).toBe(1);
+    // \r is just a regular character contributing to length
+    expect(s.utf16Len).toBe(8); // a b c \r \n d e f
+    // lastLine is "def"
+    expect(s.lastLineLen).toBe(3);
+  });
+
+  it("lone \\r does not count as a line break", () => {
+    const s = computeTextSummary("abc\rdef");
+    expect(s.lines).toBe(0);
+    expect(s.utf16Len).toBe(7);
+    // The entire string is the "last line"
+    expect(s.lastLineLen).toBe(7);
+  });
+
+  it("multi-byte UTF-8 on last line", () => {
+    const s = computeTextSummary("line1\n你好");
+    expect(s.lines).toBe(1);
+    // "你好" is 2 UTF-16 code units, 6 UTF-8 bytes
+    expect(s.lastLineLen).toBe(2);
+    expect(s.lastLineBytes).toBe(6);
+  });
+
+  it("emoji (surrogate pair) on last line", () => {
+    const s = computeTextSummary("a\n🎉");
+    expect(s.lines).toBe(1);
+    // 🎉 is 2 UTF-16 code units (surrogate pair), 4 UTF-8 bytes
+    expect(s.lastLineLen).toBe(2);
+    expect(s.lastLineBytes).toBe(4);
+  });
+
+  it("empty lines between content", () => {
+    const s = computeTextSummary("a\n\n\nb");
+    expect(s.lines).toBe(3);
+    expect(s.lastLineLen).toBe(1);
+    expect(s.lastLineBytes).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// textSummaryOps.combine
+// ---------------------------------------------------------------------------
+
+describe("textSummaryOps.combine", () => {
+  it("identity is neutral", () => {
+    const id = textSummaryOps.identity();
+    const s = computeTextSummary("hello\nworld");
+    const combined = textSummaryOps.combine(id, s);
+    expect(combined).toEqual(s);
+    const combined2 = textSummaryOps.combine(s, id);
+    expect(combined2).toEqual(s);
+  });
+
+  it("combines two chunks without newlines", () => {
+    const a = computeTextSummary("abc");
+    const b = computeTextSummary("def");
+    const c = textSummaryOps.combine(a, b);
+    expect(c.lines).toBe(0);
+    expect(c.utf16Len).toBe(6);
+    // lastLineLen should be sum since no newline in right
+    expect(c.lastLineLen).toBe(6);
+    expect(c.lastLineBytes).toBe(6);
+  });
+
+  it("combines chunks where right has newline", () => {
+    const a = computeTextSummary("abc");
+    const b = computeTextSummary("\ndef");
+    const c = textSummaryOps.combine(a, b);
+    expect(c.lines).toBe(1);
+    expect(c.utf16Len).toBe(7);
+    // right has a newline so lastLineLen comes from right only
+    expect(c.lastLineLen).toBe(3);
+    expect(c.lastLineBytes).toBe(3);
+  });
+
+  it("combines chunks where left has newline but right doesn't", () => {
+    const a = computeTextSummary("abc\n");
+    const b = computeTextSummary("def");
+    const c = textSummaryOps.combine(a, b);
+    expect(c.lines).toBe(1);
+    // right has no newline, so lastLineLen = left.lastLineLen + right.lastLineLen
+    // left.lastLineLen = 0 (ends with newline), right.lastLineLen = 3
+    expect(c.lastLineLen).toBe(3);
+  });
+
+  it("associativity with multi-byte characters", () => {
+    const a = computeTextSummary("hello\n");
+    const b = computeTextSummary("你");
+    const c = computeTextSummary("好\nend");
+
+    const ab_c = textSummaryOps.combine(textSummaryOps.combine(a, b), c);
+    const a_bc = textSummaryOps.combine(a, textSummaryOps.combine(b, c));
+    expect(ab_c).toEqual(a_bc);
+  });
+
+  it("associativity across four chunks", () => {
+    const chunks = ["ab\n", "cd", "\nef\n", "gh"].map(computeTextSummary);
+    // ((a . b) . c) . d
+    const left = chunks.reduce(
+      (acc, s) => textSummaryOps.combine(acc, s),
+      textSummaryOps.identity(),
+    );
+    // a . (b . (c . d))
+    const right = chunks.reduceRight(
+      (acc, s) => textSummaryOps.combine(s, acc),
+      textSummaryOps.identity(),
+    );
+    expect(left).toEqual(right);
+  });
+});

--- a/src/text/distributed-undo.test.ts
+++ b/src/text/distributed-undo.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "bun:test";
+import { TextBuffer } from "./text-buffer.js";
+import { replicaId } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePair() {
+  const rid1 = replicaId(1);
+  const rid2 = replicaId(2);
+  const buf1 = TextBuffer.create(rid1);
+  const buf2 = TextBuffer.create(rid2);
+  return { rid1, rid2, buf1, buf2 };
+}
+
+function makeTriple() {
+  const rid1 = replicaId(1);
+  const rid2 = replicaId(2);
+  const rid3 = replicaId(3);
+  const buf1 = TextBuffer.create(rid1);
+  const buf2 = TextBuffer.create(rid2);
+  const buf3 = TextBuffer.create(rid3);
+  return { rid1, rid2, rid3, buf1, buf2, buf3 };
+}
+
+// ---------------------------------------------------------------------------
+// Distributed undo: propagation
+// ---------------------------------------------------------------------------
+
+describe("Distributed undo propagation", () => {
+  it("undo on replica1 propagates to replica2", () => {
+    const { buf1, buf2 } = makePair();
+
+    const insertOp = buf1.insert(0, "Hello");
+    buf2.applyRemote(insertOp);
+    expect(buf2.getText()).toBe("Hello");
+
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) return;
+
+    buf2.applyRemote(undoOp);
+    expect(buf1.getText()).toBe("");
+    expect(buf2.getText()).toBe("");
+  });
+
+  it("undo + redo propagate and converge", () => {
+    const { buf1, buf2 } = makePair();
+
+    const insertOp = buf1.insert(0, "Hello");
+    buf2.applyRemote(insertOp);
+
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) return;
+    buf2.applyRemote(undoOp);
+    expect(buf2.getText()).toBe("");
+
+    const redoOp = buf1.redo();
+    expect(redoOp).not.toBeNull();
+    if (redoOp === null) return;
+    buf2.applyRemote(redoOp);
+    expect(buf1.getText()).toBe("Hello");
+    expect(buf2.getText()).toBe("Hello");
+  });
+
+  it("undo after remote insert preserves remote content", () => {
+    const { buf1, buf2 } = makePair();
+
+    // buf1 inserts "AB"
+    const op1 = buf1.insert(0, "AB");
+    buf2.applyRemote(op1);
+
+    // buf2 inserts "X" at position 1 (between A and B)
+    const op2 = buf2.insert(1, "X");
+    buf1.applyRemote(op2);
+    expect(buf1.getText()).toBe("AXB");
+
+    // buf1 undoes its own "AB" insert — "X" from buf2 should remain
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) return;
+    buf2.applyRemote(undoOp);
+
+    expect(buf1.getText()).toBe("X");
+    expect(buf2.getText()).toBe("X");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Distributed undo: concurrent undo
+// ---------------------------------------------------------------------------
+
+describe("Concurrent undo", () => {
+  it("both replicas undo their own inserts concurrently", () => {
+    const { buf1, buf2 } = makePair();
+
+    // Each replica inserts and syncs
+    const op1 = buf1.insert(0, "A");
+    const op2 = buf2.insert(0, "B");
+    buf1.applyRemote(op2);
+    buf2.applyRemote(op1);
+
+    // Both undo concurrently
+    const undo1 = buf1.undo();
+    const undo2 = buf2.undo();
+    expect(undo1).not.toBeNull();
+    expect(undo2).not.toBeNull();
+    if (undo1 === null || undo2 === null) return;
+
+    // Cross-apply undos
+    buf1.applyRemote(undo2);
+    buf2.applyRemote(undo1);
+
+    // Both should be empty
+    expect(buf1.getText()).toBe("");
+    expect(buf2.getText()).toBe("");
+  });
+
+  it("one replica undoes while other inserts", () => {
+    const { buf1, buf2 } = makePair();
+
+    const op1 = buf1.insert(0, "Hello");
+    buf2.applyRemote(op1);
+
+    // Concurrent: buf1 undoes, buf2 inserts
+    const undoOp = buf1.undo();
+    const op2 = buf2.insert(5, " World");
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) return;
+
+    buf1.applyRemote(op2);
+    buf2.applyRemote(undoOp);
+
+    // Both should converge: "Hello" undone, " World" remains
+    expect(buf1.getText()).toBe(buf2.getText());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Distributed undo: delete operations
+// ---------------------------------------------------------------------------
+
+describe("Distributed undo of deletes", () => {
+  it("undo of delete restores text on remote", () => {
+    const { buf1, buf2 } = makePair();
+
+    const insertOp = buf1.insert(0, "Hello");
+    buf2.applyRemote(insertOp);
+
+    const deleteOp = buf1.delete(1, 4); // delete "ell"
+    buf2.applyRemote(deleteOp);
+    expect(buf2.getText()).toBe("Ho");
+
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) return;
+    buf2.applyRemote(undoOp);
+
+    expect(buf1.getText()).toBe("Hello");
+    expect(buf2.getText()).toBe("Hello");
+  });
+
+  it("undo of delete after remote edit", () => {
+    const { buf1, buf2 } = makePair();
+
+    const insertOp = buf1.insert(0, "ABCDE");
+    buf2.applyRemote(insertOp);
+
+    // buf1 deletes "BCD"
+    const deleteOp = buf1.delete(1, 4);
+    buf2.applyRemote(deleteOp);
+    expect(buf2.getText()).toBe("AE");
+
+    // buf2 appends "X"
+    const appendOp = buf2.insert(2, "X");
+    buf1.applyRemote(appendOp);
+
+    // buf1 undoes the delete
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) return;
+    buf2.applyRemote(undoOp);
+
+    // Both should converge
+    expect(buf1.getText()).toBe(buf2.getText());
+    // "BCD" should be restored, "X" should still be present
+    expect(buf1.getText()).toContain("BCD");
+    expect(buf1.getText()).toContain("X");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Three-replica convergence
+// ---------------------------------------------------------------------------
+
+describe("Three-replica convergence", () => {
+  it("three concurrent inserts at same position converge", () => {
+    const { buf1, buf2, buf3 } = makeTriple();
+
+    // All three insert at position 0 concurrently
+    const op1 = buf1.insert(0, "A");
+    const op2 = buf2.insert(0, "B");
+    const op3 = buf3.insert(0, "C");
+
+    // Apply all ops to all replicas (different orders)
+    buf1.applyRemote(op2);
+    buf1.applyRemote(op3);
+
+    buf2.applyRemote(op3);
+    buf2.applyRemote(op1);
+
+    buf3.applyRemote(op1);
+    buf3.applyRemote(op2);
+
+    // All three should converge to the same text
+    expect(buf1.getText()).toBe(buf2.getText());
+    expect(buf2.getText()).toBe(buf3.getText());
+  });
+
+  it("three replicas with mixed insert/delete converge", () => {
+    const { buf1, buf2, buf3 } = makeTriple();
+
+    // Shared initial state
+    const initOp = buf1.insert(0, "Hello");
+    buf2.applyRemote(initOp);
+    buf3.applyRemote(initOp);
+
+    // Concurrent operations
+    const op1 = buf1.insert(5, " World"); // append
+    const op2 = buf2.delete(0, 1); // delete "H"
+    const op3 = buf3.insert(0, "!"); // prepend
+
+    // Apply to buf1 (has op1)
+    buf1.applyRemote(op2);
+    buf1.applyRemote(op3);
+
+    // Apply to buf2 (has op2)
+    buf2.applyRemote(op1);
+    buf2.applyRemote(op3);
+
+    // Apply to buf3 (has op3)
+    buf3.applyRemote(op1);
+    buf3.applyRemote(op2);
+
+    expect(buf1.getText()).toBe(buf2.getText());
+    expect(buf2.getText()).toBe(buf3.getText());
+  });
+
+  it("three replicas with undo converge", () => {
+    const { buf1, buf2, buf3 } = makeTriple();
+
+    // Use explicit time source to separate undo groups
+    let time = 0;
+    buf1.setTimeSource(() => time);
+
+    // Shared state
+    const initOp = buf1.insert(0, "ABC");
+    buf2.applyRemote(initOp);
+    buf3.applyRemote(initOp);
+
+    // Advance time so next insert is a separate undo group
+    time += 500;
+
+    // buf1 inserts, buf2 inserts, buf3 does nothing
+    const op1 = buf1.insert(3, "D");
+    const op2 = buf2.insert(0, "X");
+
+    // Sync all
+    buf1.applyRemote(op2);
+    buf2.applyRemote(op1);
+    buf3.applyRemote(op1);
+    buf3.applyRemote(op2);
+
+    // All should agree
+    expect(buf1.getText()).toBe(buf2.getText());
+    expect(buf2.getText()).toBe(buf3.getText());
+
+    // Now buf1 undoes its "D" insert
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) return;
+
+    buf2.applyRemote(undoOp);
+    buf3.applyRemote(undoOp);
+
+    // All converge after undo
+    expect(buf1.getText()).toBe(buf2.getText());
+    expect(buf2.getText()).toBe(buf3.getText());
+    expect(buf1.getText()).toContain("ABC");
+    expect(buf1.getText()).toContain("X");
+    expect(buf1.getText()).not.toContain("D");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot isolation under distributed undo
+// ---------------------------------------------------------------------------
+
+describe("Snapshot isolation with distributed undo", () => {
+  it("snapshot is not affected by subsequent undo", () => {
+    const buf = TextBuffer.create(replicaId(1));
+    buf.insert(0, "Hello");
+    const snap = buf.snapshot();
+    expect(snap.getText()).toBe("Hello");
+
+    buf.undo();
+    expect(buf.getText()).toBe("");
+    // Snapshot should still see the old state
+    expect(snap.getText()).toBe("Hello");
+    snap.release();
+  });
+
+  it("snapshot is not affected by remote undo", () => {
+    const { buf1, buf2 } = makePair();
+
+    const insertOp = buf1.insert(0, "World");
+    buf2.applyRemote(insertOp);
+
+    const snap = buf2.snapshot();
+    expect(snap.getText()).toBe("World");
+
+    // buf1 undoes and propagates
+    const undoOp = buf1.undo();
+    expect(undoOp).not.toBeNull();
+    if (undoOp === null) {
+      snap.release();
+      return;
+    }
+    buf2.applyRemote(undoOp);
+
+    expect(buf2.getText()).toBe("");
+    expect(snap.getText()).toBe("World");
+    snap.release();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **20 tests** for `computeTextSummary` and `byteLength` edge cases: empty strings, newlines, CRLF handling, multi-byte UTF-8 (CJK), emoji surrogate pairs, and `textSummaryOps.combine` associativity
- Adds **14 tests** for distributed undo/convergence: undo propagation across replicas, undo+redo convergence, concurrent undo, undo of delete operations, three-replica convergence with mixed operations, and snapshot isolation under distributed undo mutations

Closes #163

## Test plan

- [x] All 34 new tests pass (`bun test src/rope/summary.test.ts src/text/distributed-undo.test.ts`)
- [x] Full test suite passes (498 tests, 0 failures)
- [x] TypeScript typecheck passes
- [x] Biome lint passes (no new issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)