### PR TITLE
feat: JIT-compiled Locator comparators (exploration for #114)

### DIFF
--- a/benchmarks/jit-comparator.ts
+++ b/benchmarks/jit-comparator.ts
@@ -1,0 +1,263 @@
+/**
+ * Benchmark: JIT-compiled vs generic Locator/Fragment comparators.
+ *
+ * Tests the hypothesis from issue #114 that `new Function()`-generated
+ * comparators with unrolled loops outperform the generic loop-based version.
+ *
+ * Run: bun run benchmarks/jit-comparator.ts
+ */
+
+import { bench, group, run, summary } from "mitata";
+import {
+  compareFragmentsGeneric,
+  compareLocatorsGeneric,
+  createFragmentComparator,
+  createLocatorComparator,
+  jitCompareFragments,
+  jitCompareLocators,
+} from "../src/text/jit-comparator.js";
+import { compareLocators } from "../src/text/locator.js";
+import { replicaId } from "../src/text/types.js";
+import type { Fragment, FragmentSummary, Locator, OperationId } from "../src/text/types.js";
+
+// ---------------------------------------------------------------------------
+// Data generation
+// ---------------------------------------------------------------------------
+
+function randomLocator(maxDepth: number): Locator {
+  const depth = 1 + Math.floor(Math.random() * maxDepth);
+  const levels: number[] = [];
+  for (let i = 0; i < depth; i++) {
+    levels.push(Math.floor(Math.random() * 1_000_000));
+  }
+  return { levels };
+}
+
+function randomOpId(): OperationId {
+  return {
+    replicaId: replicaId(Math.floor(Math.random() * 10)),
+    counter: Math.floor(Math.random() * 100_000),
+  };
+}
+
+function randomFragment(maxDepth: number): Fragment {
+  const locator = randomLocator(maxDepth);
+  const insertionId = randomOpId();
+  return {
+    locator,
+    baseLocator: locator,
+    insertionId,
+    insertionOffset: Math.floor(Math.random() * 100),
+    length: 1,
+    visible: true,
+    deletions: [],
+    text: "x",
+    summary(): FragmentSummary {
+      return {
+        visibleLen: 1,
+        visibleLines: 0,
+        deletedLen: 0,
+        deletedLines: 0,
+        maxInsertionId: insertionId,
+        maxLocator: locator,
+        itemCount: 1,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Datasets
+// ---------------------------------------------------------------------------
+
+const PAIR_COUNT = 10_000;
+const SORT_SIZE = 1_000;
+
+// Locator pairs at different depths
+const shallowPairs: Array<[Locator, Locator]> = [];
+const mediumPairs: Array<[Locator, Locator]> = [];
+const deepPairs: Array<[Locator, Locator]> = [];
+
+for (let i = 0; i < PAIR_COUNT; i++) {
+  shallowPairs.push([randomLocator(2), randomLocator(2)]);
+  mediumPairs.push([randomLocator(5), randomLocator(5)]);
+  deepPairs.push([randomLocator(12), randomLocator(12)]);
+}
+
+// Fragment arrays for sort benchmarks
+function makeFragmentArray(size: number, maxDepth: number): Fragment[] {
+  const arr: Fragment[] = [];
+  for (let i = 0; i < size; i++) {
+    arr.push(randomFragment(maxDepth));
+  }
+  return arr;
+}
+
+const fragmentsShallow = makeFragmentArray(SORT_SIZE, 3);
+const fragmentsMedium = makeFragmentArray(SORT_SIZE, 6);
+const fragmentsDeep = makeFragmentArray(SORT_SIZE, 12);
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+const jitD4 = createLocatorComparator(4);
+const jitD16 = createLocatorComparator(16);
+const jitFragD16 = createFragmentComparator(16);
+
+summary(() => {
+  group("Locator compare: shallow (depth 1-2)", () => {
+    bench("original compareLocators", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = shallowPairs[i] as [Locator, Locator];
+        sum += compareLocators(a, b);
+      }
+      return sum;
+    });
+
+    bench("generic (optimized baseline)", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = shallowPairs[i] as [Locator, Locator];
+        sum += compareLocatorsGeneric(a, b);
+      }
+      return sum;
+    });
+
+    bench("JIT depth=4", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = shallowPairs[i] as [Locator, Locator];
+        sum += jitD4(a, b);
+      }
+      return sum;
+    });
+
+    bench("JIT depth=8 (default)", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = shallowPairs[i] as [Locator, Locator];
+        sum += jitCompareLocators(a, b);
+      }
+      return sum;
+    });
+  });
+
+  group("Locator compare: medium (depth 1-5)", () => {
+    bench("original compareLocators", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = mediumPairs[i] as [Locator, Locator];
+        sum += compareLocators(a, b);
+      }
+      return sum;
+    });
+
+    bench("generic (optimized baseline)", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = mediumPairs[i] as [Locator, Locator];
+        sum += compareLocatorsGeneric(a, b);
+      }
+      return sum;
+    });
+
+    bench("JIT depth=8 (default)", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = mediumPairs[i] as [Locator, Locator];
+        sum += jitCompareLocators(a, b);
+      }
+      return sum;
+    });
+  });
+
+  group("Locator compare: deep (depth 1-12)", () => {
+    bench("original compareLocators", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = deepPairs[i] as [Locator, Locator];
+        sum += compareLocators(a, b);
+      }
+      return sum;
+    });
+
+    bench("generic (optimized baseline)", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = deepPairs[i] as [Locator, Locator];
+        sum += compareLocatorsGeneric(a, b);
+      }
+      return sum;
+    });
+
+    bench("JIT depth=8 (default)", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = deepPairs[i] as [Locator, Locator];
+        sum += jitCompareLocators(a, b);
+      }
+      return sum;
+    });
+
+    bench("JIT depth=16", () => {
+      let sum = 0;
+      for (let i = 0; i < PAIR_COUNT; i++) {
+        const [a, b] = deepPairs[i] as [Locator, Locator];
+        sum += jitD16(a, b);
+      }
+      return sum;
+    });
+  });
+
+  group(`Fragment sort: ${SORT_SIZE} items, shallow locators`, () => {
+    bench("Array.sort + generic comparator", () => {
+      const arr = [...fragmentsShallow];
+      arr.sort(compareFragmentsGeneric);
+      return arr[0];
+    });
+
+    bench("Array.sort + JIT comparator (d8)", () => {
+      const arr = [...fragmentsShallow];
+      arr.sort(jitCompareFragments);
+      return arr[0];
+    });
+  });
+
+  group(`Fragment sort: ${SORT_SIZE} items, medium locators`, () => {
+    bench("Array.sort + generic comparator", () => {
+      const arr = [...fragmentsMedium];
+      arr.sort(compareFragmentsGeneric);
+      return arr[0];
+    });
+
+    bench("Array.sort + JIT comparator (d8)", () => {
+      const arr = [...fragmentsMedium];
+      arr.sort(jitCompareFragments);
+      return arr[0];
+    });
+  });
+
+  group(`Fragment sort: ${SORT_SIZE} items, deep locators`, () => {
+    bench("Array.sort + generic comparator", () => {
+      const arr = [...fragmentsDeep];
+      arr.sort(compareFragmentsGeneric);
+      return arr[0];
+    });
+
+    bench("Array.sort + JIT comparator (d8)", () => {
+      const arr = [...fragmentsDeep];
+      arr.sort(jitCompareFragments);
+      return arr[0];
+    });
+
+    bench("Array.sort + JIT comparator (d16)", () => {
+      const arr = [...fragmentsDeep];
+      arr.sort(jitFragD16);
+      return arr[0];
+    });
+  });
+});
+
+run();

--- a/src/text/jit-comparator.test.ts
+++ b/src/text/jit-comparator.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compareFragmentsGeneric,
+  compareLocatorsGeneric,
+  createFragmentComparator,
+  createLocatorComparator,
+  jitCompareFragments,
+  jitCompareLocators,
+  jitCompareLocatorsDeep,
+} from "./jit-comparator.js";
+import { compareLocators } from "./locator.js";
+import { replicaId } from "./types.js";
+import type { Fragment, FragmentSummary, Locator, OperationId } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loc(...levels: number[]): Locator {
+  return { levels };
+}
+
+function opId(replica: number, counter: number): OperationId {
+  return { replicaId: replicaId(replica), counter };
+}
+
+function frag(locator: Locator, insertionId: OperationId, insertionOffset = 0): Fragment {
+  return {
+    locator,
+    baseLocator: locator,
+    insertionId,
+    insertionOffset,
+    length: 1,
+    visible: true,
+    deletions: [],
+    text: "x",
+    summary(): FragmentSummary {
+      return {
+        visibleLen: 1,
+        visibleLines: 0,
+        deletedLen: 0,
+        deletedLines: 0,
+        maxInsertionId: insertionId,
+        maxLocator: locator,
+        itemCount: 1,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Locator comparator tests
+// ---------------------------------------------------------------------------
+
+describe("JIT locator comparator", () => {
+  const comparators: Array<[string, (a: Locator, b: Locator) => number]> = [
+    ["generic", compareLocatorsGeneric],
+    ["jit-d8", jitCompareLocators],
+    ["jit-d16", jitCompareLocatorsDeep],
+    ["jit-d4 (custom)", createLocatorComparator(4)],
+  ];
+
+  for (const [name, cmp] of comparators) {
+    describe(name, () => {
+      test("equal locators", () => {
+        expect(cmp(loc(1, 2, 3), loc(1, 2, 3))).toBe(0);
+      });
+
+      test("single level less", () => {
+        expect(cmp(loc(1), loc(2))).toBeLessThan(0);
+      });
+
+      test("single level greater", () => {
+        expect(cmp(loc(5), loc(3))).toBeGreaterThan(0);
+      });
+
+      test("multi-level comparison", () => {
+        expect(cmp(loc(1, 2, 3), loc(1, 2, 4))).toBeLessThan(0);
+        expect(cmp(loc(1, 3, 0), loc(1, 2, 9))).toBeGreaterThan(0);
+      });
+
+      test("shorter locator sorts before longer with same prefix", () => {
+        expect(cmp(loc(1, 2), loc(1, 2, 3))).toBeLessThan(0);
+      });
+
+      test("longer locator sorts after shorter with same prefix", () => {
+        expect(cmp(loc(1, 2, 3), loc(1, 2))).toBeGreaterThan(0);
+      });
+
+      test("empty levels", () => {
+        expect(cmp(loc(), loc())).toBe(0);
+        expect(cmp(loc(), loc(1))).toBeLessThan(0);
+        expect(cmp(loc(1), loc())).toBeGreaterThan(0);
+      });
+
+      test("matches reference compareLocators", () => {
+        const pairs: Array<[Locator, Locator]> = [
+          [loc(0), loc(Number.MAX_SAFE_INTEGER)],
+          [loc(1, 2, 3, 4, 5, 6, 7, 8), loc(1, 2, 3, 4, 5, 6, 7, 9)],
+          [loc(10), loc(10, 0)],
+          [loc(5, 5), loc(5, 5)],
+          [loc(1, 0, 0, 0, 0), loc(1, 0, 0, 0, 1)],
+        ];
+        for (const [a, b] of pairs) {
+          expect(Math.sign(cmp(a, b))).toBe(Math.sign(compareLocators(a, b)));
+          expect(Math.sign(cmp(b, a))).toBe(Math.sign(compareLocators(b, a)));
+        }
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fragment comparator tests
+// ---------------------------------------------------------------------------
+
+describe("JIT fragment comparator", () => {
+  const comparators: Array<[string, (a: Fragment, b: Fragment) => number]> = [
+    ["generic", compareFragmentsGeneric],
+    ["jit-d8", jitCompareFragments],
+    ["jit-d8 (custom)", createFragmentComparator(8)],
+  ];
+
+  for (const [name, cmp] of comparators) {
+    describe(name, () => {
+      test("different locators", () => {
+        const a = frag(loc(1), opId(1, 1));
+        const b = frag(loc(2), opId(1, 1));
+        expect(cmp(a, b)).toBeLessThan(0);
+        expect(cmp(b, a)).toBeGreaterThan(0);
+      });
+
+      test("same locator, different operation ID (replicaId)", () => {
+        const a = frag(loc(5, 3), opId(1, 1));
+        const b = frag(loc(5, 3), opId(2, 1));
+        expect(cmp(a, b)).toBeLessThan(0);
+      });
+
+      test("same locator, different operation ID (counter)", () => {
+        const a = frag(loc(5, 3), opId(1, 1));
+        const b = frag(loc(5, 3), opId(1, 2));
+        expect(cmp(a, b)).toBeLessThan(0);
+      });
+
+      test("same locator and opId, different offset", () => {
+        const a = frag(loc(5, 3), opId(1, 1), 0);
+        const b = frag(loc(5, 3), opId(1, 1), 5);
+        expect(cmp(a, b)).toBeLessThan(0);
+      });
+
+      test("equal fragments", () => {
+        const a = frag(loc(5, 3), opId(1, 1), 0);
+        const b = frag(loc(5, 3), opId(1, 1), 0);
+        expect(cmp(a, b)).toBe(0);
+      });
+
+      test("sort produces same order as generic", () => {
+        const frags = [
+          frag(loc(3, 1), opId(2, 5), 0),
+          frag(loc(1, 2), opId(1, 1), 0),
+          frag(loc(3, 1), opId(1, 3), 0),
+          frag(loc(1, 2), opId(1, 1), 3),
+          frag(loc(2), opId(3, 1), 0),
+        ];
+
+        const sortedGeneric = [...frags].sort(compareFragmentsGeneric);
+        const sortedJIT = [...frags].sort(cmp);
+
+        for (let i = 0; i < frags.length; i++) {
+          expect(sortedJIT[i]).toBe(sortedGeneric[i]);
+        }
+      });
+    });
+  }
+});

--- a/src/text/jit-comparator.ts
+++ b/src/text/jit-comparator.ts
@@ -1,0 +1,203 @@
+/**
+ * JIT-compiled Locator comparators using `new Function()`.
+ *
+ * V8/Bun optimize monomorphic call sites and predictable branches.
+ * By generating a comparator unrolled for a known max depth, we eliminate:
+ * - The `Math.min()` call
+ * - The loop and its branch mispredictions
+ * - The `undefined` guard checks
+ *
+ * Falls back to the generic `compareLocators` when `new Function()` is
+ * unavailable (CSP-restricted environments).
+ *
+ * @see https://github.com/iamnbutler/crdt/issues/114
+ */
+
+import type { Fragment, Locator } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A comparator function for Locators. */
+export type LocatorCompareFn = (a: Locator, b: Locator) => number;
+
+/** A comparator function for Fragments (full sort key). */
+export type FragmentCompareFn = (a: Fragment, b: Fragment) => number;
+
+// ---------------------------------------------------------------------------
+// Generic (fallback) comparators
+// ---------------------------------------------------------------------------
+
+/**
+ * Generic lexicographic Locator comparison — the baseline.
+ * Used as fallback when JIT compilation is unavailable.
+ */
+export function compareLocatorsGeneric(a: Locator, b: Locator): number {
+  const aLevels = a.levels;
+  const bLevels = b.levels;
+  const minLen = aLevels.length < bLevels.length ? aLevels.length : bLevels.length;
+  for (let i = 0; i < minLen; i++) {
+    const d = (aLevels[i] as number) - (bLevels[i] as number);
+    if (d !== 0) return d;
+  }
+  return aLevels.length - bLevels.length;
+}
+
+/**
+ * Generic fragment comparison — full sort key.
+ */
+export function compareFragmentsGeneric(a: Fragment, b: Fragment): number {
+  const locCmp = compareLocatorsGeneric(a.locator, b.locator);
+  if (locCmp !== 0) return locCmp;
+
+  const aId = a.insertionId;
+  const bId = b.insertionId;
+  if (aId.replicaId !== bId.replicaId) return aId.replicaId - bId.replicaId;
+  if (aId.counter !== bId.counter) return aId.counter - bId.counter;
+
+  const offsetCmp = a.insertionOffset - b.insertionOffset;
+  if (offsetCmp !== 0) return offsetCmp;
+
+  return a.locator.levels.length - b.locator.levels.length;
+}
+
+// ---------------------------------------------------------------------------
+// JIT compilation
+// ---------------------------------------------------------------------------
+
+/** Whether `new Function()` is available in this environment. */
+let jitAvailable: boolean | undefined;
+
+function canJIT(): boolean {
+  if (jitAvailable !== undefined) return jitAvailable;
+  try {
+    const probe = new Function("return 42");
+    jitAvailable = probe() === 42;
+  } catch {
+    jitAvailable = false;
+  }
+  return jitAvailable;
+}
+
+/**
+ * Generate the body of an unrolled locator comparator for a given max depth.
+ *
+ * The generated function accesses `a.levels` and `b.levels` directly by index,
+ * with explicit length checks to handle variable-depth locators.
+ */
+function generateLocatorCompareBody(maxDepth: number): string {
+  const lines: string[] = [];
+  lines.push("var al = a.levels, bl = b.levels;");
+  lines.push("var aLen = al.length, bLen = bl.length;");
+  lines.push("var d;");
+
+  for (let i = 0; i < maxDepth; i++) {
+    lines.push(`if (aLen <= ${i} || bLen <= ${i}) return aLen - bLen;`);
+    lines.push(`d = al[${i}] - bl[${i}]; if (d !== 0) return d;`);
+  }
+
+  // Fallback loop for locators deeper than maxDepth
+  lines.push("var minLen = aLen < bLen ? aLen : bLen;");
+  lines.push(`for (var i = ${maxDepth}; i < minLen; i++) {`);
+  lines.push("  d = al[i] - bl[i]; if (d !== 0) return d;");
+  lines.push("}");
+  lines.push("return aLen - bLen;");
+  return lines.join("\n");
+}
+
+/**
+ * Generate the body of a JIT-compiled fragment comparator.
+ * Inlines the locator comparison to avoid an extra function call.
+ */
+function generateFragmentCompareBody(maxDepth: number): string {
+  // Wrap the unrolled locator comparison in a do-while(false) so `break` works
+  const lines = [
+    "do {",
+    "  var al = a.locator.levels, bl = b.locator.levels;",
+    "  var aLen = al.length, bLen = bl.length;",
+    "  var minLen = aLen < bLen ? aLen : bLen;",
+    "  var d;",
+  ];
+
+  for (let i = 0; i < maxDepth; i++) {
+    lines.push(`  if (${i} >= minLen) { d = aLen - bLen; if (d !== 0) return d; break; }`);
+    lines.push(`  d = al[${i}] - bl[${i}]; if (d !== 0) return d;`);
+  }
+
+  // Fallback loop for locators deeper than maxDepth
+  lines.push(`  for (var i = ${maxDepth}; i < minLen; i++) {`);
+  lines.push("    d = al[i] - bl[i]; if (d !== 0) return d;");
+  lines.push("  }");
+  lines.push("  d = aLen - bLen; if (d !== 0) return d;");
+  lines.push("} while (false);");
+
+  // Operation ID comparison
+  lines.push("var aId = a.insertionId, bId = b.insertionId;");
+  lines.push("if (aId.replicaId !== bId.replicaId) return aId.replicaId - bId.replicaId;");
+  lines.push("if (aId.counter !== bId.counter) return aId.counter - bId.counter;");
+
+  // Insertion offset
+  lines.push("d = a.insertionOffset - b.insertionOffset;");
+  lines.push("if (d !== 0) return d;");
+
+  // Final tie-break: locator depth
+  lines.push("return a.locator.levels.length - b.locator.levels.length;");
+
+  return lines.join("\n");
+}
+
+/**
+ * Create a JIT-compiled locator comparator optimized for locators up to
+ * `maxDepth` levels deep. Falls back to the generic comparator if JIT
+ * is unavailable.
+ *
+ * @param maxDepth - Maximum expected locator depth. Locators deeper than
+ *   this are still compared correctly (via length tie-break), but won't
+ *   benefit from unrolling.
+ */
+export function createLocatorComparator(maxDepth = 8): LocatorCompareFn {
+  if (!canJIT()) return compareLocatorsGeneric;
+
+  const body = generateLocatorCompareBody(maxDepth);
+  const fn = new Function("a", "b", body) as LocatorCompareFn;
+
+  // Add sourceURL for better stack traces
+  try {
+    const bodyWithSourceURL = `${body}\n//# sourceURL=crdt-jit-locator-compare-d${maxDepth}.js`;
+    return new Function("a", "b", bodyWithSourceURL) as LocatorCompareFn;
+  } catch {
+    return fn;
+  }
+}
+
+/**
+ * Create a JIT-compiled fragment comparator with the locator comparison
+ * inlined (no function-call overhead for the locator part).
+ *
+ * @param maxDepth - Maximum expected locator depth for unrolling.
+ */
+export function createFragmentComparator(maxDepth = 8): FragmentCompareFn {
+  if (!canJIT()) return compareFragmentsGeneric;
+
+  const body = generateFragmentCompareBody(maxDepth);
+  try {
+    const bodyWithSourceURL = `${body}\n//# sourceURL=crdt-jit-fragment-compare-d${maxDepth}.js`;
+    return new Function("a", "b", bodyWithSourceURL) as FragmentCompareFn;
+  } catch {
+    return compareFragmentsGeneric;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pre-built comparators for common depths
+// ---------------------------------------------------------------------------
+
+/** JIT-compiled locator comparator for depth <= 8 (covers most documents). */
+export const jitCompareLocators: LocatorCompareFn = createLocatorComparator(8);
+
+/** JIT-compiled locator comparator for deep documents (depth <= 16). */
+export const jitCompareLocatorsDeep: LocatorCompareFn = createLocatorComparator(16);
+
+/** JIT-compiled fragment comparator for depth <= 8. */
+export const jitCompareFragments: FragmentCompareFn = createFragmentComparator(8);


### PR DESCRIPTION
## Summary

Explores the hypothesis from #114 that `new Function()`-generated comparators with unrolled loops can significantly outperform generic loop-based Locator comparison.

- Adds `src/text/jit-comparator.ts` — JIT comparator factory with CSP-safe fallback
- Adds `src/text/jit-comparator.test.ts` — 50 tests verifying correctness against reference `compareLocators`
- Adds `benchmarks/jit-comparator.ts` — mitata benchmarks comparing all variants

## Benchmark Results (Bun 1.3.11, arm64-linux)

**Locator comparison (10K pairs):**
| Variant | Shallow (d1-2) | Medium (d1-5) | Deep (d1-12) |
|---------|---------------|---------------|--------------|
| Original `compareLocators` | 69µs | 68µs | 69µs |
| Generic (optimized) | 77µs | 69µs | 73µs |
| **JIT depth=8** | **66µs** | **66µs** | **70µs** |

**Fragment sort (1000 items):**
| Variant | Shallow | Medium | Deep |
|---------|---------|--------|------|
| Generic comparator | 81µs | 77µs | 81µs |
| **JIT comparator (d8)** | **71µs** | **70µs** | **71µs** |

**Result: ~10-14% improvement in sort, ~3-4% in raw comparison.**

## Key Findings

The 10x improvement claimed in #114 is **not realized**. The reasons:

1. **No megamorphic IC issue** — All `Locator` objects share the same hidden class (`{ levels: number[] }`), so V8/Bun already generates monomorphic inline caches for the generic comparator
2. **Bun's JIT already optimizes the loop** — The simple `for` loop in `compareLocators` is already well-optimized
3. **Most comparisons resolve at depth 1** — The unrolled levels beyond the first rarely matter for early-exit

The real performance bottleneck is the **O(n) array rebuild** in `sortFragments()` (extracting all fragments, sorting, rebuilding the SumTree), not the per-comparison cost. The O(log n) cursor-based approach in `docs/plans/2026-03-25-ologn-fragment-ops-design.md` would eliminate this entirely.

## What This PR Provides

- Ready-to-use JIT comparator module (opt-in, not wired into TextBuffer)
- Comprehensive benchmark suite for future comparison work
- Evidence-based conclusion: **focus optimization effort on eliminating the sort, not speeding it up**

Closes #114

## Test plan

- [x] All 50 JIT comparator tests pass
- [x] Full test suite (4016 tests) passes
- [x] TypeScript strict mode passes
- [x] Benchmarks run without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)