### PR TITLE
fix: correct redistributeNodes leaf order with right sibling

### DIFF
--- a/src/sum-tree/index.test.ts
+++ b/src/sum-tree/index.test.ts
@@ -320,6 +320,29 @@ describe("SumTree", () => {
       expect(invariants.valid).toBe(true);
     });
 
+    it("preserves item order when redistributing with right sibling", () => {
+      // Use BF=4 so min items per leaf is 2, max is 4.
+      // Build a tree where deleting from the leftmost leaf triggers
+      // redistribution with the right sibling (not merge).
+      let tree = new SumTree<CountItem, CountSummary>(countSummaryOps, 4);
+
+      // Insert items 0..7 to get a 2-leaf tree after splitting
+      for (let i = 0; i < 8; i++) {
+        tree = tree.push(new CountItem(i));
+      }
+
+      // Delete from the front until redistribution with right sibling fires.
+      // After each delete, items must remain in sorted order.
+      for (let i = 0; i < 4; i++) {
+        tree = tree.removeAt(0);
+        const arr = tree.toArray().map((x) => x.value);
+        // Items should be consecutive integers starting at i+1
+        expect(arr).toEqual([...Array(7 - i)].map((_, j) => j + i + 1));
+        const invariants = tree.checkInvariants();
+        expect(invariants.valid).toBe(true);
+      }
+    });
+
     it("maintains all leaves at same depth", () => {
       let tree = new SumTree<CountItem, CountSummary>(countSummaryOps, 4);
 

--- a/src/sum-tree/index.ts
+++ b/src/sum-tree/index.ts
@@ -1882,10 +1882,9 @@ export class SumTree<T extends Summarizable<S>, S> {
       const nodeItems = nodeData?.items ?? [];
       const siblingItems = siblingData?.items ?? [];
 
-      const total = [...siblingItems, ...nodeItems];
-      if (!siblingIsLeft) {
-        total.reverse();
-      }
+      const total = siblingIsLeft
+        ? [...siblingItems, ...nodeItems]
+        : [...nodeItems, ...siblingItems];
 
       const mid = Math.floor(total.length / 2);
       const leftItems = total.slice(0, mid);


### PR DESCRIPTION
## Summary

- **Fix**: Replace `total.reverse()` in `redistributeNodes` leaf case with conditional spread (`siblingIsLeft ? [...sib, ...node] : [...node, ...sib]`), matching the internal-node pattern. The `reverse()` call scrambled item order when redistributing with a right sibling.
- **Test**: Add targeted test that builds a BF=4 tree with 8 items, deletes from the front to trigger right-sibling redistribution, and verifies items remain in sorted order.
- All 3,967 existing tests continue to pass.

## Bug Details

When a leftmost leaf underflows and the right sibling has enough items to redistribute (but not merge), `total.reverse()` reverses the combined item array. For items `[a, b]` (node) and `[c, d, e]` (right sibling), reverse produces `[e, d, c, b, a]` instead of the correct `[a, b, c, d, e]`.

## Test plan

- [x] New test verifies right-sibling redistribution preserves item order
- [x] All 3,967 tests pass
- [x] Biome lint clean

Closes #174
Supersedes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)