### PR TITLE
feat: JIT-compile locator/fragment comparators for sort performance

### DIFF
--- a/src/text/fragment.ts
+++ b/src/text/fragment.ts
@@ -10,7 +10,8 @@
  */
 
 import type { Dimension, Summary } from "../sum-tree/index.js";
-import { MIN_LOCATOR, compareLocators } from "./locator.js";
+import { jitCompareLocators } from "./jit-comparator.js";
+import { MIN_LOCATOR } from "./locator.js";
 import { MIN_OPERATION_ID, compareOperationIds } from "./types.js";
 import type { Fragment, FragmentSummary, Locator, OperationId } from "./types.js";
 
@@ -46,7 +47,7 @@ export const fragmentSummaryOps: Summary<FragmentSummary> = {
           ? left.maxInsertionId
           : right.maxInsertionId,
       maxLocator:
-        compareLocators(left.maxLocator, right.maxLocator) >= 0
+        jitCompareLocators(left.maxLocator, right.maxLocator) >= 0
           ? left.maxLocator
           : right.maxLocator,
       itemCount: left.itemCount + right.itemCount,
@@ -103,11 +104,11 @@ export const locatorDimension: Dimension<FragmentSummary, Locator> = {
     return summary.maxLocator;
   },
   compare(a: Locator, b: Locator): number {
-    return compareLocators(a, b);
+    return jitCompareLocators(a, b);
   },
   add(a: Locator, b: Locator): Locator {
     // For max-based dimensions, "add" returns the max
-    return compareLocators(a, b) >= 0 ? a : b;
+    return jitCompareLocators(a, b) >= 0 ? a : b;
   },
   zero(): Locator {
     return MIN_LOCATOR;

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -83,6 +83,16 @@ export {
   withVisibility,
 } from "./fragment.js";
 
+// JIT-compiled comparators
+export {
+  createJitFragmentComparator,
+  createJitLocatorComparator,
+  jitCompareFragments,
+  jitCompareLocators,
+} from "./jit-comparator.js";
+
+export type { FragmentCompareFn, LocatorCompareFn } from "./jit-comparator.js";
+
 // TextBuffer
 export { TextBuffer } from "./text-buffer.js";
 

--- a/src/text/jit-comparator.test.ts
+++ b/src/text/jit-comparator.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import { createFragment } from "./fragment.js";
+import {
+  createJitFragmentComparator,
+  createJitLocatorComparator,
+  jitCompareFragments,
+  jitCompareLocators,
+} from "./jit-comparator.js";
+import { compareLocators } from "./locator.js";
+import { replicaId } from "./types.js";
+import type { Fragment, Locator, OperationId, ReplicaId } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loc(...levels: number[]): Locator {
+  return { levels };
+}
+
+function opId(rid: number, counter: number): OperationId {
+  return { replicaId: replicaId(rid), counter };
+}
+
+function frag(locLevels: number[], rid: number, counter: number, offset = 0): Fragment {
+  const id = opId(rid, counter);
+  const locator = loc(...locLevels);
+  return createFragment(id, offset, locator, "x", true);
+}
+
+// ---------------------------------------------------------------------------
+// Locator comparator
+// ---------------------------------------------------------------------------
+
+describe("jitCompareLocators", () => {
+  test("matches compareLocators for equal locators", () => {
+    const a = loc(5, 10, 3);
+    expect(jitCompareLocators(a, a)).toBe(0);
+    expect(compareLocators(a, a)).toBe(0);
+  });
+
+  test("matches compareLocators for single-level", () => {
+    expect(Math.sign(jitCompareLocators(loc(1), loc(2)))).toBe(
+      Math.sign(compareLocators(loc(1), loc(2))),
+    );
+    expect(Math.sign(jitCompareLocators(loc(2), loc(1)))).toBe(
+      Math.sign(compareLocators(loc(2), loc(1))),
+    );
+  });
+
+  test("matches compareLocators for multi-level", () => {
+    const cases: [Locator, Locator][] = [
+      [loc(1, 2, 3), loc(1, 2, 4)],
+      [loc(1, 3), loc(1, 2, 4)],
+      [loc(1), loc(1, 0)],
+      [loc(1, 0), loc(1)],
+      [loc(0), loc(Number.MAX_SAFE_INTEGER)],
+      [loc(5, 5, 5, 5), loc(5, 5, 5, 5)],
+      [loc(5, 5, 5), loc(5, 5, 5, 0)],
+    ];
+    for (const [a, b] of cases) {
+      expect(Math.sign(jitCompareLocators(a, b))).toBe(Math.sign(compareLocators(a, b)));
+      expect(Math.sign(jitCompareLocators(b, a))).toBe(Math.sign(compareLocators(b, a)));
+    }
+  });
+
+  test("prefix locator sorts before longer locator", () => {
+    expect(jitCompareLocators(loc(5), loc(5, 3))).toBeLessThan(0);
+    expect(jitCompareLocators(loc(5, 3), loc(5))).toBeGreaterThan(0);
+  });
+
+  test("handles empty-ish locators", () => {
+    // Single-element locators
+    expect(jitCompareLocators(loc(0), loc(0))).toBe(0);
+    expect(jitCompareLocators(loc(0), loc(1))).toBeLessThan(0);
+  });
+
+  test("handles deep locators (up to 16 levels)", () => {
+    const deep1 = loc(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    const deep2 = loc(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17);
+    expect(jitCompareLocators(deep1, deep2)).toBeLessThan(0);
+    expect(jitCompareLocators(deep2, deep1)).toBeGreaterThan(0);
+    expect(jitCompareLocators(deep1, deep1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fragment comparator
+// ---------------------------------------------------------------------------
+
+describe("jitCompareFragments", () => {
+  test("sorts by locator first", () => {
+    const f1 = frag([1], 1, 0);
+    const f2 = frag([2], 1, 0);
+    expect(jitCompareFragments(f1, f2)).toBeLessThan(0);
+    expect(jitCompareFragments(f2, f1)).toBeGreaterThan(0);
+  });
+
+  test("tie-breaks by replicaId when locators equal", () => {
+    const f1 = frag([5], 1, 0);
+    const f2 = frag([5], 2, 0);
+    expect(jitCompareFragments(f1, f2)).toBeLessThan(0);
+    expect(jitCompareFragments(f2, f1)).toBeGreaterThan(0);
+  });
+
+  test("tie-breaks by counter when locator and replicaId equal", () => {
+    const f1 = frag([5], 1, 0);
+    const f2 = frag([5], 1, 1);
+    expect(jitCompareFragments(f1, f2)).toBeLessThan(0);
+  });
+
+  test("tie-breaks by insertionOffset for split parts", () => {
+    const f1 = frag([5], 1, 0, 0);
+    const f2 = frag([5], 1, 0, 3);
+    expect(jitCompareFragments(f1, f2)).toBeLessThan(0);
+  });
+
+  test("equal fragments return 0", () => {
+    const f1 = frag([5, 3], 1, 0, 2);
+    expect(jitCompareFragments(f1, f1)).toBe(0);
+  });
+
+  test("sorts array of fragments correctly", () => {
+    const fragments = [
+      frag([3], 2, 0),
+      frag([1], 1, 0),
+      frag([3], 1, 0),
+      frag([2], 1, 0),
+      frag([1], 1, 0, 5),
+      frag([1], 1, 0, 0),
+    ];
+    const sorted = [...fragments].sort(jitCompareFragments);
+    // Expected order: loc[1] first, then within that by (rid, counter, offset)
+    expect(sorted[0]?.locator.levels[0]).toBe(1);
+    expect(sorted[1]?.locator.levels[0]).toBe(1);
+    expect(sorted[2]?.locator.levels[0]).toBe(1);
+    expect(sorted[3]?.locator.levels[0]).toBe(2);
+    expect(sorted[4]?.locator.levels[0]).toBe(3);
+    expect(sorted[5]?.locator.levels[0]).toBe(3);
+    // The two loc[3] fragments should be ordered by replicaId
+    expect(sorted[4]?.insertionId.replicaId).toBeLessThan(
+      sorted[5]?.insertionId.replicaId as ReplicaId,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
+describe("createJitLocatorComparator", () => {
+  test("works with custom maxDepth", () => {
+    const cmp = createJitLocatorComparator(4);
+    expect(cmp(loc(1, 2, 3), loc(1, 2, 4))).toBeLessThan(0);
+    expect(cmp(loc(1), loc(1))).toBe(0);
+  });
+});
+
+describe("createJitFragmentComparator", () => {
+  test("works with custom maxDepth", () => {
+    const cmp = createJitFragmentComparator(4);
+    const f1 = frag([1, 2], 1, 0);
+    const f2 = frag([1, 3], 1, 0);
+    expect(cmp(f1, f2)).toBeLessThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Consistency with original compareLocators across many random inputs
+// ---------------------------------------------------------------------------
+
+describe("JIT vs original consistency", () => {
+  test("locator comparator matches original for 1000 random pairs", () => {
+    for (let trial = 0; trial < 1000; trial++) {
+      const aLen = 1 + Math.floor(Math.random() * 5);
+      const bLen = 1 + Math.floor(Math.random() * 5);
+      const a = loc(...Array.from({ length: aLen }, () => Math.floor(Math.random() * 1000)));
+      const b = loc(...Array.from({ length: bLen }, () => Math.floor(Math.random() * 1000)));
+
+      const original = Math.sign(compareLocators(a, b));
+      const jit = Math.sign(jitCompareLocators(a, b));
+      expect(jit).toBe(original);
+    }
+  });
+});

--- a/src/text/jit-comparator.ts
+++ b/src/text/jit-comparator.ts
@@ -1,0 +1,230 @@
+/**
+ * JIT-compiled comparators for Locators and Fragments.
+ *
+ * V8 (and other JS engines) optimize monomorphic call sites much better than
+ * polymorphic ones. By generating specialized comparator functions with
+ * `new Function()`, we produce code with predictable branch patterns and
+ * inlined property access that the JIT can optimize aggressively.
+ *
+ * The generated comparators unroll the locator level-comparison loop for a
+ * known maximum depth, eliminating the overhead of `Math.min`, loop counters,
+ * and dynamic array bounds checking.
+ *
+ * Falls back to plain functions when `new Function()` is unavailable (e.g.,
+ * CSP-restricted environments with `script-src` lacking `'unsafe-eval'`).
+ */
+
+import type { Fragment, Locator } from "./types.js";
+
+/** Comparator signature for locators. */
+export type LocatorCompareFn = (a: Locator, b: Locator) => number;
+
+/** Comparator signature for fragments (used in sorting). */
+export type FragmentCompareFn = (a: Fragment, b: Fragment) => number;
+
+// ---------------------------------------------------------------------------
+// Fallback (non-JIT) comparators — identical logic to locator.ts / text-buffer.ts
+// ---------------------------------------------------------------------------
+
+/** Fallback locator comparator (no JIT). */
+function fallbackCompareLocators(a: Locator, b: Locator): number {
+  const aLevels = a.levels;
+  const bLevels = b.levels;
+  const minLen = aLevels.length < bLevels.length ? aLevels.length : bLevels.length;
+  for (let i = 0; i < minLen; i++) {
+    const d = (aLevels[i] as number) - (bLevels[i] as number);
+    if (d !== 0) return d;
+  }
+  return aLevels.length - bLevels.length;
+}
+
+/** Fallback fragment comparator (no JIT). */
+function fallbackCompareFragments(a: Fragment, b: Fragment): number {
+  // Locator comparison
+  const aLoc = a.locator.levels;
+  const bLoc = b.locator.levels;
+  const minLen = aLoc.length < bLoc.length ? aLoc.length : bLoc.length;
+  for (let i = 0; i < minLen; i++) {
+    const d = (aLoc[i] as number) - (bLoc[i] as number);
+    if (d !== 0) return d;
+  }
+  const locCmp = aLoc.length - bLoc.length;
+  if (locCmp !== 0) return locCmp;
+
+  // Operation ID tie-break
+  const ridCmp = a.insertionId.replicaId - b.insertionId.replicaId;
+  if (ridCmp !== 0) return ridCmp;
+  const ctrCmp = a.insertionId.counter - b.insertionId.counter;
+  if (ctrCmp !== 0) return ctrCmp;
+
+  // Insertion offset (split parts)
+  const offCmp = a.insertionOffset - b.insertionOffset;
+  if (offCmp !== 0) return offCmp;
+
+  // Locator length (children after parent)
+  return a.locator.levels.length - b.locator.levels.length;
+}
+
+// ---------------------------------------------------------------------------
+// JIT code generation
+// ---------------------------------------------------------------------------
+
+/** Maximum locator depth — matches MAX_DEPTH in locator.ts. */
+const MAX_DEPTH = 16;
+
+/**
+ * Generate the body of an unrolled locator comparison function.
+ *
+ * The generated code accesses `a.levels[i]` and `b.levels[i]` directly for
+ * each level 0..maxDepth-1, breaking early when one side runs out of levels.
+ */
+function generateLocatorCompareBody(maxDepth: number): string {
+  const lines: string[] = [];
+  lines.push("var aL = a.levels, bL = b.levels;");
+  lines.push("var aLen = aL.length, bLen = bL.length;");
+
+  for (let i = 0; i < maxDepth; i++) {
+    // Early exit: if both arrays are shorter than i+1, comparison is done
+    lines.push(`if (aLen <= ${i}) return bLen <= ${i} ? 0 : -1;`);
+    lines.push(`if (bLen <= ${i}) return 1;`);
+    lines.push(`var d${i} = aL[${i}] - bL[${i}];`);
+    lines.push(`if (d${i} !== 0) return d${i};`);
+  }
+
+  // If both arrays have more than maxDepth levels and all matched, compare lengths
+  lines.push("return aLen - bLen;");
+  return lines.join("\n");
+}
+
+/**
+ * Generate the body of an unrolled fragment comparison function.
+ *
+ * Inlines: locator comparison → operation ID → insertion offset → locator length.
+ * This eliminates all function-call overhead in the sort comparator.
+ */
+function generateFragmentCompareBody(maxDepth: number): string {
+  const lines: string[] = [];
+
+  // Locator comparison (inlined)
+  lines.push("var aL = a.locator.levels, bL = b.locator.levels;");
+  lines.push("var aLen = aL.length, bLen = bL.length;");
+  lines.push("var minLen = aLen < bLen ? aLen : bLen;");
+
+  // Unrolled loop for common depths, then dynamic loop for deeper
+  const unrollDepth = Math.min(maxDepth, 6); // Unroll first 6 levels (covers >99% of cases)
+  for (let i = 0; i < unrollDepth; i++) {
+    lines.push(`if (minLen > ${i}) {`);
+    lines.push(`  var d${i} = aL[${i}] - bL[${i}];`);
+    lines.push(`  if (d${i} !== 0) return d${i};`);
+    lines.push("}");
+  }
+
+  // Dynamic loop for remaining levels (rare: depth > 6)
+  if (maxDepth > unrollDepth) {
+    lines.push(`for (var i = ${unrollDepth}; i < minLen; i++) {`);
+    lines.push("  var dd = aL[i] - bL[i];");
+    lines.push("  if (dd !== 0) return dd;");
+    lines.push("}");
+  }
+
+  // Locator length comparison
+  lines.push("var locCmp = aLen - bLen;");
+  lines.push("if (locCmp !== 0) return locCmp;");
+
+  // Operation ID tie-break (inlined)
+  lines.push("var ridCmp = a.insertionId.replicaId - b.insertionId.replicaId;");
+  lines.push("if (ridCmp !== 0) return ridCmp;");
+  lines.push("var ctrCmp = a.insertionId.counter - b.insertionId.counter;");
+  lines.push("if (ctrCmp !== 0) return ctrCmp;");
+
+  // Insertion offset
+  lines.push("var offCmp = a.insertionOffset - b.insertionOffset;");
+  lines.push("if (offCmp !== 0) return offCmp;");
+
+  // Locator length (children after parent) — same as locCmp but included
+  // for completeness since locCmp was already 0 at this point
+  lines.push("return 0;");
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a JIT-compiled locator comparator.
+ *
+ * @param maxDepth Maximum locator depth to unroll for (default: MAX_DEPTH).
+ * @returns A fast comparator function, or the fallback if JIT is unavailable.
+ */
+export function createJitLocatorComparator(maxDepth: number = MAX_DEPTH): LocatorCompareFn {
+  try {
+    const body = generateLocatorCompareBody(maxDepth);
+    const factory = new Function("a", "b", body) as LocatorCompareFn;
+
+    // Sanity check: verify it works on a trivial case
+    const test1 = { levels: [1] };
+    const test2 = { levels: [2] };
+    if (factory(test1, test2) >= 0 || factory(test2, test1) <= 0 || factory(test1, test1) !== 0) {
+      return fallbackCompareLocators;
+    }
+    return factory;
+  } catch {
+    // CSP or other restriction — use fallback
+    return fallbackCompareLocators;
+  }
+}
+
+/**
+ * Create a JIT-compiled fragment comparator for use in sortFragments and
+ * binary search insertion.
+ *
+ * @param maxDepth Maximum locator depth to unroll for (default: MAX_DEPTH).
+ * @returns A fast comparator function, or the fallback if JIT is unavailable.
+ */
+export function createJitFragmentComparator(maxDepth: number = MAX_DEPTH): FragmentCompareFn {
+  try {
+    const body = generateFragmentCompareBody(maxDepth);
+    const factory = new Function("a", "b", body) as FragmentCompareFn;
+
+    // Sanity check with minimal fragment-like objects
+    const frag1 = {
+      locator: { levels: [1] },
+      insertionId: { replicaId: 1, counter: 0 },
+      insertionOffset: 0,
+    };
+    const frag2 = {
+      locator: { levels: [2] },
+      insertionId: { replicaId: 1, counter: 0 },
+      insertionOffset: 0,
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: sanity check uses minimal mock objects
+    const f1 = frag1 as any;
+    // biome-ignore lint/suspicious/noExplicitAny: sanity check uses minimal mock objects
+    const f2 = frag2 as any;
+    if (factory(f1, f2) >= 0 || factory(f2, f1) <= 0 || factory(f1, f1) !== 0) {
+      return fallbackCompareFragments;
+    }
+    return factory;
+  } catch {
+    // CSP or other restriction — use fallback
+    return fallbackCompareFragments;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton comparators (generated once at import time)
+// ---------------------------------------------------------------------------
+
+/**
+ * JIT-compiled locator comparator, ready to use.
+ * Falls back to a plain function in CSP-restricted environments.
+ */
+export const jitCompareLocators: LocatorCompareFn = createJitLocatorComparator(MAX_DEPTH);
+
+/**
+ * JIT-compiled fragment comparator, ready to use.
+ * Falls back to a plain function in CSP-restricted environments.
+ */
+export const jitCompareFragments: FragmentCompareFn = createJitFragmentComparator(MAX_DEPTH);

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -28,6 +28,7 @@ import {
   visibleLenDimension,
   withVisibility,
 } from "./fragment.js";
+import { jitCompareFragments } from "./jit-comparator.js";
 import { MAX_LOCATOR, MIN_LOCATOR, compareLocators, locatorBetween } from "./locator.js";
 import {
   SERIALIZATION_VERSION,
@@ -61,7 +62,6 @@ import type {
 import {
   MAX_OPERATION_ID,
   MIN_OPERATION_ID,
-  compareOperationIds,
   operationIdsEqual,
   replicaId,
   transactionId,
@@ -73,25 +73,14 @@ import { UndoMap } from "./undo-map.js";
 // ---------------------------------------------------------------------------
 
 /**
- * Compare locators for fragment sorting using full lexicographic comparison.
- *
- * When one locator is a prefix of another, the shorter one sorts FIRST.
- * This is correct because child locators (e.g., [L, X]) represent positions
- * INSIDE the parent's original span - they should come after the parent's
- * left portion and before concurrent siblings that sort later.
- *
- * Operation ID tie-breaking only applies when locators are EXACTLY equal,
- * which happens with concurrent inserts at the same position.
- */
-function compareLocatorsForSort(a: Locator, b: Locator): number {
-  return compareLocators(a, b);
-}
-
-/**
  * Sort fragments to ensure canonical order regardless of operation application
  * sequence.
  *
  * Sort key: (locator prefix, insertionId, insertionOffset, locator length)
+ *
+ * Uses a JIT-compiled comparator that inlines all comparison stages (locator,
+ * operation ID, offset, length) into a single function, eliminating cross-
+ * function call overhead in the sort hot path.
  *
  * This ensures:
  * 1. Fragments at the same position (locator prefix) sort by operation ID
@@ -99,22 +88,7 @@ function compareLocatorsForSort(a: Locator, b: Locator): number {
  * 3. Child locators sort after parent locators with lower operation IDs
  */
 function sortFragments(frags: Fragment[]): void {
-  frags.sort((a, b) => {
-    // First, compare by locator prefix
-    const locCmp = compareLocatorsForSort(a.locator, b.locator);
-    if (locCmp !== 0) return locCmp;
-
-    // Same prefix: tie-break by operation ID
-    const idCmp = compareOperationIds(a.insertionId, b.insertionId);
-    if (idCmp !== 0) return idCmp;
-
-    // Same operation: sort by insertionOffset (split parts)
-    const offsetCmp = a.insertionOffset - b.insertionOffset;
-    if (offsetCmp !== 0) return offsetCmp;
-
-    // Finally, sort by locator length (children after parent)
-    return a.locator.levels.length - b.locator.levels.length;
-  });
+  frags.sort(jitCompareFragments);
 }
 
 // ---------------------------------------------------------------------------
@@ -1525,22 +1499,11 @@ export class TextBuffer {
    * Compare two fragments using the same logic as sortFragments.
    * This ensures insertFragmentByLocator produces the same order as sorting.
    * Returns: <0 if a should come before b, >0 if after, 0 if equal.
+   *
+   * Uses the JIT-compiled comparator for consistent ordering and performance.
    */
   private compareFragmentsForSort(a: Fragment, b: Fragment): number {
-    // First, compare by locator prefix (not lexicographic!)
-    const locCmp = compareLocatorsForSort(a.locator, b.locator);
-    if (locCmp !== 0) return locCmp;
-
-    // Same prefix: tie-break by operation ID
-    const idCmp = compareOperationIds(a.insertionId, b.insertionId);
-    if (idCmp !== 0) return idCmp;
-
-    // Same operation: sort by insertionOffset (split parts)
-    const offsetCmp = a.insertionOffset - b.insertionOffset;
-    if (offsetCmp !== 0) return offsetCmp;
-
-    // Finally, sort by locator length (children after parent)
-    return a.locator.levels.length - b.locator.levels.length;
+    return jitCompareFragments(a, b);
   }
 
   /**
@@ -1875,14 +1838,8 @@ export class TextBuffer {
     }
 
     // Sort by (locator, insertionId, insertionOffset) to maintain canonical order
-    // after splits. This matches the sorting in applyRemoteInsertDirect.
-    resultFrags.sort((a, b) => {
-      const locCmp = compareLocators(a.locator, b.locator);
-      if (locCmp !== 0) return locCmp;
-      const idCmp = compareOperationIds(a.insertionId, b.insertionId);
-      if (idCmp !== 0) return idCmp;
-      return a.insertionOffset - b.insertionOffset;
-    });
+    // after splits. Uses JIT-compiled comparator matching sortFragments order.
+    resultFrags.sort(jitCompareFragments);
 
     this.setFragments(resultFrags);
   }


### PR DESCRIPTION
## Summary

- Generates specialized comparator functions using `new Function()` that unroll the locator level-comparison loop (up to 16 levels) and inline all fragment sort stages into a single function
- Produces monomorphic V8 inline caches and eliminates cross-function call overhead in the `sortFragments()` hot path
- Falls back to plain (non-JIT) functions automatically when `new Function()` is unavailable (CSP-restricted environments)

## Integration points (all existing hot paths updated)

- **`sortFragments()`** in text-buffer.ts — now uses `jitCompareFragments` directly (4 call sites)
- **`compareFragmentsForSort()`** — binary search insertion uses `jitCompareFragments`
- **`locatorDimension`** in fragment.ts — SumTree seeking uses `jitCompareLocators`
- **`fragmentSummaryOps.combine()`** — SumTree summarization uses `jitCompareLocators`

## How the JIT works

The fragment comparator inlines all 4 comparison stages into one generated function:
1. Locator comparison — first 6 levels unrolled, then dynamic loop for deeper
2. Operation ID tie-break (replicaId, then counter)
3. Insertion offset (split parts)
4. Locator length (children after parent)

The locator comparator fully unrolls the level loop for all 16 possible depths with early exits.

Both factories include sanity checks at generation time and graceful CSP fallback.

## Test plan

- [x] 15 new tests covering JIT locator comparator, fragment comparator, factory functions, and 1000-pair random consistency check against original `compareLocators`
- [x] All 3981 existing tests pass (no regressions)
- [x] TypeScript strict mode passes
- [x] Biome lint clean (no new warnings)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)