### PR TITLE
feat: operation batching with intent detection (typing coalescer)

### DIFF
--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -25,6 +25,7 @@ import {
   textSummaryOps,
 } from "../src/sum-tree/index.js";
 import { TextBuffer } from "../src/text/index.js";
+import { OperationBatcher } from "../src/text/operation-batcher.js";
 import { loadEditingTrace } from "./fixtures.js";
 import { type DocumentSize, generateSyntheticDocument } from "./synthetic.js";
 
@@ -437,6 +438,65 @@ if (editingTrace) {
               buf.insert(Math.min(op.position, buf.length), op.insertText);
             }
           }
+          return buf;
+        },
+      );
+    });
+  }
+  // ---------------------------------------------------------------------------
+  // Batched trace replay (OperationBatcher coalescing)
+  // ---------------------------------------------------------------------------
+
+  group("editing-trace-batched", () => {
+    for (const count of [1000, 10000, 50000]) {
+      if (count > editingTrace.operations.length) continue;
+      const subset = editingTrace.operations.slice(0, count);
+
+      bench(`batched replay ${count.toLocaleString()} ops`, () => {
+        const buf = TextBuffer.create();
+        const batcher = new OperationBatcher(buf, { flushDelay: 0, maxBatchSize: 200 });
+        for (const op of subset) {
+          if (op.deleteCount > 0) {
+            const len = batcher.getLength();
+            if (len > 0) {
+              const start = Math.min(op.position, len);
+              const end = Math.min(op.position + op.deleteCount, len);
+              if (end > start) batcher.delete(start, end);
+            }
+          }
+          if (op.insertText) {
+            const len = batcher.getLength();
+            batcher.insert(Math.min(op.position, len), op.insertText);
+          }
+        }
+        batcher.flush();
+        return buf;
+      });
+    }
+  });
+
+  if (!isCI) {
+    group("editing-trace-batched-full", () => {
+      bench(
+        `batched replay full trace (${editingTrace.operations.length.toLocaleString()} ops)`,
+        () => {
+          const buf = TextBuffer.create();
+          const batcher = new OperationBatcher(buf, { flushDelay: 0, maxBatchSize: 200 });
+          for (const op of editingTrace.operations) {
+            if (op.deleteCount > 0) {
+              const len = batcher.getLength();
+              if (len > 0) {
+                const start = Math.min(op.position, len);
+                const end = Math.min(op.position + op.deleteCount, len);
+                if (end > start) batcher.delete(start, end);
+              }
+            }
+            if (op.insertText) {
+              const len = batcher.getLength();
+              batcher.insert(Math.min(op.position, len), op.insertText);
+            }
+          }
+          batcher.flush();
           return buf;
         },
       );

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -86,6 +86,10 @@ export {
 // TextBuffer
 export { TextBuffer } from "./text-buffer.js";
 
+// Operation Batcher
+export { OperationBatcher } from "./operation-batcher.js";
+export type { OperationBatcherOptions } from "./operation-batcher.js";
+
 // Snapshot
 export { TextBufferSnapshot } from "./snapshot.js";
 

--- a/src/text/operation-batcher.test.ts
+++ b/src/text/operation-batcher.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test";
+import { OperationBatcher } from "./operation-batcher.js";
+import { TextBuffer } from "./text-buffer.js";
+
+describe("OperationBatcher", () => {
+  test("single insert flushes correctly", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "a");
+    expect(batcher.hasPending).toBe(true);
+    expect(batcher.pendingLength).toBe(1);
+
+    const ops = batcher.flush();
+    expect(ops.length).toBe(1);
+    expect(buf.getText()).toBe("a");
+    expect(batcher.hasPending).toBe(false);
+  });
+
+  test("sequential inserts are coalesced", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "h");
+    batcher.insert(1, "e");
+    batcher.insert(2, "l");
+    batcher.insert(3, "l");
+    batcher.insert(4, "o");
+
+    expect(batcher.pendingLength).toBe(5);
+    expect(batcher.coalescedCount).toBe(4);
+
+    batcher.flush();
+    expect(buf.getText()).toBe("hello");
+    expect(batcher.flushCount).toBe(1);
+  });
+
+  test("non-sequential insert triggers flush and starts new batch", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    // Type "ab" sequentially
+    batcher.insert(0, "a");
+    batcher.insert(1, "b");
+    expect(batcher.coalescedCount).toBe(1);
+
+    // Jump to a different position — should flush "ab", then start "x"
+    batcher.insert(0, "x");
+    expect(batcher.flushCount).toBe(1);
+    expect(buf.getText()).toBe("ab");
+
+    // Flush the "x"
+    batcher.flush();
+    expect(buf.getText()).toBe("xab");
+    expect(batcher.flushCount).toBe(2);
+  });
+
+  test("delete flushes pending inserts first", () => {
+    const buf = TextBuffer.fromString("hello world");
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    // Add some text
+    batcher.insert(5, "!");
+    expect(batcher.hasPending).toBe(true);
+
+    // Delete should flush first
+    batcher.delete(0, 5);
+    expect(batcher.hasPending).toBe(false);
+    expect(buf.getText()).toBe("! world");
+  });
+
+  test("getText flushes pending inserts", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "h");
+    batcher.insert(1, "i");
+
+    expect(batcher.getText()).toBe("hi");
+    expect(batcher.hasPending).toBe(false);
+  });
+
+  test("getLength flushes pending inserts", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "a");
+    batcher.insert(1, "b");
+    batcher.insert(2, "c");
+
+    expect(batcher.getLength()).toBe(3);
+  });
+
+  test("maxBatchSize triggers auto-flush", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0, maxBatchSize: 5 });
+
+    for (let i = 0; i < 5; i++) {
+      batcher.insert(i, String.fromCharCode(97 + i));
+    }
+
+    // Should have auto-flushed at maxBatchSize
+    expect(batcher.flushCount).toBe(1);
+    expect(buf.getText()).toBe("abcde");
+    expect(batcher.hasPending).toBe(false);
+  });
+
+  test("multi-char inserts are coalesced when sequential", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "hel");
+    batcher.insert(3, "lo");
+
+    expect(batcher.pendingLength).toBe(5);
+    batcher.flush();
+    expect(buf.getText()).toBe("hello");
+    expect(batcher.flushCount).toBe(1);
+  });
+
+  test("empty insert is ignored", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "");
+    expect(batcher.hasPending).toBe(false);
+  });
+
+  test("flush with nothing pending returns empty array", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    const ops = batcher.flush();
+    expect(ops.length).toBe(0);
+    expect(batcher.flushCount).toBe(0);
+  });
+
+  test("onOperation callback fires on flush", () => {
+    const buf = TextBuffer.create();
+    const ops: unknown[] = [];
+    const batcher = new OperationBatcher(buf, {
+      flushDelay: 0,
+      onOperation: (op) => ops.push(op),
+    });
+
+    batcher.insert(0, "a");
+    batcher.insert(1, "b");
+    batcher.flush();
+
+    expect(ops.length).toBe(1);
+    expect((ops[0] as { type: string }).type).toBe("insert");
+  });
+
+  test("onOperation callback fires on delete", () => {
+    const buf = TextBuffer.fromString("hello");
+    const ops: unknown[] = [];
+    const batcher = new OperationBatcher(buf, {
+      flushDelay: 0,
+      onOperation: (op) => ops.push(op),
+    });
+
+    batcher.delete(0, 3);
+    expect(ops.length).toBe(1);
+    expect((ops[0] as { type: string }).type).toBe("delete");
+  });
+
+  test("applyRemote flushes pending inserts first", () => {
+    const source = TextBuffer.create();
+    const remoteOp = source.insert(0, "remote");
+
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "local");
+    expect(batcher.hasPending).toBe(true);
+
+    batcher.applyRemote(remoteOp);
+    expect(batcher.hasPending).toBe(false);
+    // Both local and remote text should be present
+    const text = buf.getText();
+    expect(text).toContain("local");
+    expect(text).toContain("remote");
+  });
+
+  test("dispose flushes and returns operations", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "a");
+    batcher.insert(1, "b");
+
+    const ops = batcher.dispose();
+    expect(ops.length).toBe(1);
+    expect(buf.getText()).toBe("ab");
+    expect(batcher.hasPending).toBe(false);
+  });
+
+  test("getBuffer flushes and returns underlying buffer", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "test");
+    const returned = batcher.getBuffer();
+    expect(returned).toBe(buf);
+    expect(returned.getText()).toBe("test");
+  });
+
+  test("rawBuffer returns buffer without flushing", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    batcher.insert(0, "pending");
+    expect(batcher.rawBuffer).toBe(buf);
+    expect(buf.getText()).toBe(""); // Not flushed yet
+    expect(batcher.hasPending).toBe(true);
+  });
+
+  test("realistic typing simulation: sequential chars then cursor jump", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    // Type "Hello" at position 0
+    for (let i = 0; i < 5; i++) {
+      batcher.insert(i, "Hello".charAt(i));
+    }
+    expect(batcher.coalescedCount).toBe(4);
+
+    // Type " World" continuing
+    for (let i = 0; i < 6; i++) {
+      batcher.insert(5 + i, " World".charAt(i));
+    }
+    expect(batcher.coalescedCount).toBe(10); // all coalesced into one batch
+
+    // Flush
+    batcher.flush();
+    expect(buf.getText()).toBe("Hello World");
+    expect(batcher.flushCount).toBe(1); // Single flush for all 11 chars
+  });
+
+  test("interleaved typing and deletion", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0 });
+
+    // Type "Hello"
+    for (let i = 0; i < 5; i++) {
+      batcher.insert(i, "Hello".charAt(i));
+    }
+
+    // Delete forces flush, then deletes
+    batcher.delete(4, 5); // Remove the "o"
+    expect(buf.getText()).toBe("Hell");
+
+    // Continue typing
+    batcher.insert(4, "o");
+    batcher.insert(5, "!");
+    batcher.flush();
+    expect(buf.getText()).toBe("Hello!");
+  });
+
+  test("large batch coalescing matches direct insert", () => {
+    const text = "The quick brown fox jumps over the lazy dog. ".repeat(20);
+
+    // Direct insert
+    const directBuf = TextBuffer.create();
+    directBuf.insert(0, text);
+
+    // Batched char-by-char insert
+    const batchBuf = TextBuffer.create();
+    const batcher = new OperationBatcher(batchBuf, { flushDelay: 0, maxBatchSize: 1000 });
+    for (let i = 0; i < text.length; i++) {
+      batcher.insert(i, text.charAt(i));
+    }
+    batcher.flush();
+
+    expect(batchBuf.getText()).toBe(text);
+    expect(batcher.flushCount).toBe(1);
+    expect(batcher.coalescedCount).toBe(text.length - 1);
+  });
+
+  test("multiple sequential runs produce correct text", () => {
+    const buf = TextBuffer.create();
+    const batcher = new OperationBatcher(buf, { flushDelay: 0, maxBatchSize: 50 });
+
+    // First typing run
+    const first = "hello ";
+    for (let i = 0; i < first.length; i++) {
+      batcher.insert(i, first.charAt(i));
+    }
+    batcher.flush();
+
+    // Second typing run (continuing at cursor)
+    const second = "world";
+    for (let i = 0; i < second.length; i++) {
+      batcher.insert(first.length + i, second.charAt(i));
+    }
+    batcher.flush();
+
+    expect(buf.getText()).toBe("hello world");
+    expect(batcher.flushCount).toBe(2);
+  });
+});

--- a/src/text/operation-batcher.ts
+++ b/src/text/operation-batcher.ts
@@ -1,0 +1,224 @@
+/**
+ * OperationBatcher: Coalesces sequential character insertions into batched
+ * string inserts to dramatically reduce tree operations during typical typing.
+ *
+ * The observation: ~95% of real editing operations are sequential character
+ * insertions at a cursor. Instead of processing 10,000 single-char inserts
+ * (each requiring a tree traversal), we coalesce them into ~50 string inserts.
+ *
+ * CRDT correctness: Each batched insert is a single TextBuffer.insert() call
+ * with a multi-character string. The TextBuffer already handles multi-char
+ * inserts as single fragments with one Locator — this is correct because
+ * local sequential typing at the same cursor position produces a contiguous
+ * run that can be represented as one fragment. If a remote op arrives or
+ * the cursor moves, the batch is flushed first.
+ */
+
+import type { TextBuffer } from "./text-buffer.js";
+import type { Operation } from "./types.js";
+
+/** A pending insert that may be extended with additional characters. */
+interface PendingInsert {
+  /** The document offset where the insert started. */
+  startOffset: number;
+  /** The accumulated text to insert. */
+  text: string;
+}
+
+export interface OperationBatcherOptions {
+  /**
+   * Maximum number of characters to accumulate before auto-flushing.
+   * Default: 100.
+   */
+  maxBatchSize?: number;
+
+  /**
+   * Auto-flush delay in milliseconds. After this period of no activity,
+   * the pending batch is flushed. Set to 0 to disable timer-based flushing.
+   * Default: 16 (one frame).
+   */
+  flushDelay?: number;
+
+  /**
+   * Callback invoked with each Operation produced by a flush.
+   * Useful for broadcasting operations to remote peers.
+   */
+  onOperation?: (op: Operation) => void;
+}
+
+export class OperationBatcher {
+  private buffer: TextBuffer;
+  private pending: PendingInsert | null;
+  private maxBatchSize: number;
+  private flushDelay: number;
+  private flushTimer: ReturnType<typeof setTimeout> | null;
+  private onOperation: ((op: Operation) => void) | null;
+
+  /** Count of inserts coalesced (for diagnostics). */
+  private _coalesced: number;
+  /** Count of flushes performed (for diagnostics). */
+  private _flushCount: number;
+
+  constructor(buffer: TextBuffer, options?: OperationBatcherOptions) {
+    this.buffer = buffer;
+    this.pending = null;
+    this.maxBatchSize = options?.maxBatchSize ?? 100;
+    this.flushDelay = options?.flushDelay ?? 16;
+    this.flushTimer = null;
+    this.onOperation = options?.onOperation ?? null;
+    this._coalesced = 0;
+    this._flushCount = 0;
+  }
+
+  /**
+   * Insert a character (or short string) at the given document offset.
+   * Sequential inserts at the cursor position are coalesced into a single
+   * batched insert.
+   */
+  insert(offset: number, text: string): void {
+    if (text.length === 0) return;
+
+    if (this.pending !== null) {
+      // Check if this insert is sequential (appending right after the pending text)
+      const expectedOffset = this.pending.startOffset + this.pending.text.length;
+      if (offset === expectedOffset) {
+        // Coalesce: extend the pending insert
+        this.pending.text += text;
+        this._coalesced++;
+        this.deferFlush();
+        return;
+      }
+
+      // Non-sequential: flush the old batch, then start a new one
+      this.flush();
+    }
+
+    // Start a new pending insert
+    this.pending = { startOffset: offset, text };
+    this.deferFlush();
+  }
+
+  /**
+   * Delete text in the range [start, end).
+   * Flushes any pending insert first to maintain ordering correctness.
+   */
+  delete(start: number, end: number): Operation {
+    this.flush();
+    const op = this.buffer.delete(start, end);
+    if (this.onOperation !== null) {
+      this.onOperation(op);
+    }
+    return op;
+  }
+
+  /**
+   * Flush any pending inserts to the underlying TextBuffer.
+   * Returns the operations produced (empty array if nothing was pending).
+   */
+  flush(): Operation[] {
+    this.clearTimer();
+
+    if (this.pending === null) {
+      return [];
+    }
+
+    const { startOffset, text } = this.pending;
+    this.pending = null;
+    this._flushCount++;
+
+    const op = this.buffer.insert(startOffset, text);
+    if (this.onOperation !== null) {
+      this.onOperation(op);
+    }
+    return [op];
+  }
+
+  /**
+   * Apply a remote operation. Flushes pending local inserts first to
+   * ensure correct ordering (remote ops must not interleave with a
+   * partially-accumulated local batch).
+   */
+  applyRemote(operation: Operation): void {
+    this.flush();
+    this.buffer.applyRemote(operation);
+  }
+
+  /** Get the visible text. Flushes pending inserts first. */
+  getText(): string {
+    this.flush();
+    return this.buffer.getText();
+  }
+
+  /** Get the visible text length. Flushes pending inserts first. */
+  getLength(): number {
+    if (this.pending !== null) {
+      this.flush();
+    }
+    return this.buffer.length;
+  }
+
+  /** Access the underlying TextBuffer (flushes first). */
+  getBuffer(): TextBuffer {
+    this.flush();
+    return this.buffer;
+  }
+
+  /** Access the underlying TextBuffer without flushing (for reads that don't need consistency). */
+  get rawBuffer(): TextBuffer {
+    return this.buffer;
+  }
+
+  /** Whether there are pending inserts that haven't been flushed. */
+  get hasPending(): boolean {
+    return this.pending !== null;
+  }
+
+  /** Number of characters currently pending. */
+  get pendingLength(): number {
+    return this.pending?.text.length ?? 0;
+  }
+
+  /** Total number of single-char inserts that were coalesced into existing batches. */
+  get coalescedCount(): number {
+    return this._coalesced;
+  }
+
+  /** Total number of flush operations performed. */
+  get flushCount(): number {
+    return this._flushCount;
+  }
+
+  /** Dispose the batcher, flushing any pending inserts and clearing timers. */
+  dispose(): Operation[] {
+    const ops = this.flush();
+    this.clearTimer();
+    return ops;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private deferFlush(): void {
+    // Force-flush if batch is at capacity
+    if (this.pending !== null && this.pending.text.length >= this.maxBatchSize) {
+      this.flush();
+      return;
+    }
+
+    // Schedule a timer-based flush (if enabled)
+    if (this.flushDelay > 0 && this.flushTimer === null) {
+      this.flushTimer = setTimeout(() => {
+        this.flushTimer = null;
+        this.flush();
+      }, this.flushDelay);
+    }
+  }
+
+  private clearTimer(): void {
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #115

- Adds `OperationBatcher` class that coalesces sequential character insertions into batched multi-char string inserts, reducing tree operations during typical typing workloads
- Automatic flush on: max batch size (default 100), non-sequential insert, delete, remote op arrival, or any read operation
- Includes 20 unit tests covering coalescing, flush triggers, remote op ordering, and correctness
- Adds batched replay benchmarks alongside existing editing trace benchmarks for direct comparison

## Design

The batcher sits above `TextBuffer` at the application layer. It detects sequential typing (inserts where `offset === prevOffset + prevText.length`) and accumulates them into a single pending insert. On flush, one `TextBuffer.insert()` call handles the entire batch as a single fragment — no per-character tree traversals.

CRDT correctness is preserved because:
- Each flush produces a proper `InsertOperation` with correct Locator
- Pending inserts are always flushed before remote ops, deletes, or reads
- The `onOperation` callback enables broadcasting ops to peers

## Test plan

- [x] All 3986 existing tests pass (no regressions)
- [x] 20 new unit tests for OperationBatcher
- [x] TypeScript strict mode passes
- [x] Biome lint passes
- [x] Verified batched output matches unbatched output (correctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)