### PR TITLE
feat: Web Worker module for off-main-thread CRDT

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
     "./anchor": {
       "types": "./dist/anchor/index.d.ts",
       "import": "./dist/anchor/index.js"
+    },
+    "./worker": {
+      "types": "./dist/worker/index.d.ts",
+      "import": "./dist/worker/index.js"
+    },
+    "./worker/crdt-worker": {
+      "types": "./dist/worker/crdt-worker.d.ts",
+      "import": "./dist/worker/crdt-worker.js"
     }
   },
   "files": [
@@ -40,7 +48,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/arena/index.ts ./src/sum-tree/index.ts ./src/rope/index.ts ./src/text/index.ts ./src/protocol/index.ts ./src/anchor/index.ts --outdir ./dist --target node --splitting",
+    "build:js": "bun build ./src/index.ts ./src/arena/index.ts ./src/sum-tree/index.ts ./src/rope/index.ts ./src/text/index.ts ./src/protocol/index.ts ./src/anchor/index.ts ./src/worker/index.ts ./src/worker/crdt-worker.ts --outdir ./dist --target node --splitting",
     "build:types": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",

--- a/src/worker/crdt-worker.ts
+++ b/src/worker/crdt-worker.ts
@@ -1,0 +1,156 @@
+/**
+ * CRDT Worker Entry Point
+ *
+ * Hosts the TextBuffer inside a Web Worker. Receives requests from the
+ * main thread via postMessage, executes them against the TextBuffer,
+ * and sends back responses. Before every mutation response, a sync event
+ * is sent with the updated text snapshot so the main thread has current
+ * state by the time the response promise resolves.
+ *
+ * Usage (browser):
+ *   const worker = new Worker(new URL('./crdt-worker.js', import.meta.url), { type: 'module' });
+ *
+ * Usage (Bun):
+ *   const worker = new Worker(new URL('./crdt-worker.ts', import.meta.url), { type: 'module' });
+ */
+
+import { TextBuffer } from "../text/text-buffer.js";
+import type { SyncEvent, WorkerRequest, WorkerResponse } from "./types.js";
+
+let buffer: TextBuffer | undefined;
+
+function sendResponse(response: WorkerResponse): void {
+  postMessage(response);
+}
+
+/** Send sync event BEFORE the response so main thread state is current when the promise resolves. */
+function sendSync(): void {
+  if (buffer === undefined) return;
+  const event: SyncEvent = {
+    type: "sync",
+    text: buffer.getText(),
+    length: buffer.length,
+  };
+  postMessage(event);
+}
+
+function handleMessage(request: WorkerRequest): void {
+  try {
+    switch (request.type) {
+      case "create": {
+        buffer = TextBuffer.create(request.replicaId);
+        sendSync();
+        sendResponse({ type: "ack", id: request.id });
+        break;
+      }
+      case "fromString": {
+        buffer = TextBuffer.fromString(request.text, request.replicaId);
+        sendSync();
+        sendResponse({ type: "ack", id: request.id });
+        break;
+      }
+      case "insert": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        const op = buffer.insert(request.offset, request.text);
+        sendSync();
+        sendResponse({ type: "operation", id: request.id, operation: op });
+        break;
+      }
+      case "delete": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        const op = buffer.delete(request.start, request.end);
+        sendSync();
+        sendResponse({ type: "operation", id: request.id, operation: op });
+        break;
+      }
+      case "undo": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        const op = buffer.undo();
+        if (op !== null) sendSync();
+        sendResponse({ type: "operation", id: request.id, operation: op });
+        break;
+      }
+      case "redo": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        const op = buffer.redo();
+        if (op !== null) sendSync();
+        sendResponse({ type: "operation", id: request.id, operation: op });
+        break;
+      }
+      case "applyRemote": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        buffer.applyRemote(request.operation);
+        sendSync();
+        sendResponse({ type: "ack", id: request.id });
+        break;
+      }
+      case "applyRemoteBatch": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        for (const operation of request.operations) {
+          buffer.applyRemote(operation);
+        }
+        sendSync();
+        sendResponse({ type: "ack", id: request.id });
+        break;
+      }
+      case "getText": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        sendResponse({ type: "text", id: request.id, text: buffer.getText() });
+        break;
+      }
+      case "getLength": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        sendResponse({ type: "length", id: request.id, length: buffer.length });
+        break;
+      }
+      case "getVersion": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        sendResponse({ type: "version", id: request.id, version: buffer.version });
+        break;
+      }
+      case "setGroupDelay": {
+        if (buffer === undefined) {
+          sendResponse({ type: "error", id: request.id, message: "Buffer not initialized" });
+          return;
+        }
+        buffer.setGroupDelay(request.ms);
+        sendResponse({ type: "ack", id: request.id });
+        break;
+      }
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    sendResponse({ type: "error", id: request.id, message });
+  }
+}
+
+addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
+  handleMessage(event.data);
+});

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Worker Module
+ *
+ * Off-main-thread CRDT processing via Web Workers. The main thread holds
+ * only a text snapshot for rendering; all CRDT state and merge logic
+ * lives in the worker.
+ *
+ * Two entry points:
+ * - `WorkerTextBuffer` (main thread): async proxy that sends commands to the worker
+ * - `crdt-worker.ts` (worker thread): hosts the TextBuffer and processes commands
+ *
+ * @example
+ * ```ts
+ * import { WorkerTextBuffer } from "@iamnbutler/crdt/worker";
+ *
+ * // Create with a URL pointing to the worker entry point
+ * const buffer = await WorkerTextBuffer.fromString(
+ *   new URL("@iamnbutler/crdt/worker/crdt-worker", import.meta.url),
+ *   "Hello, world!",
+ * );
+ *
+ * // All operations are async — main thread never blocks
+ * const op = await buffer.insert(7, "CRDT ");
+ * console.log(buffer.text); // "Hello, CRDT world!"
+ *
+ * // Listen for sync events (after every mutation)
+ * buffer.onSync = (text, length) => {
+ *   renderEditor(text);
+ * };
+ *
+ * // Broadcast operations to other replicas
+ * if (op) sendToNetwork(op);
+ *
+ * // Clean up
+ * buffer.terminate();
+ * ```
+ */
+
+export const WORKER_VERSION = "0.1.0";
+
+// Main-thread client
+export { WorkerTextBuffer, type SyncCallback } from "./worker-text-buffer.js";
+
+// Protocol types
+export type {
+  // Requests (main → worker)
+  WorkerRequest,
+  CreateRequest,
+  FromStringRequest,
+  InsertRequest,
+  DeleteRequest,
+  UndoRequest,
+  RedoRequest,
+  ApplyRemoteRequest,
+  ApplyRemoteBatchRequest,
+  GetTextRequest,
+  GetLengthRequest,
+  GetVersionRequest,
+  SetGroupDelayRequest,
+  // Responses (worker → main)
+  WorkerResponse,
+  OperationResponse,
+  TextResponse,
+  LengthResponse,
+  VersionResponse,
+  AckResponse,
+  ErrorResponse,
+  SyncEvent,
+} from "./types.js";

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -1,0 +1,174 @@
+/**
+ * Worker Protocol Types
+ *
+ * Defines the message protocol between the main thread and the CRDT worker.
+ * All communication is via postMessage with structured clone serialization.
+ */
+
+import type { Operation, ReplicaId, VersionVector } from "../text/types.js";
+
+// ---------------------------------------------------------------------------
+// Request messages (main thread → worker)
+// ---------------------------------------------------------------------------
+
+/** Create a new empty TextBuffer in the worker. */
+export interface CreateRequest {
+  readonly type: "create";
+  readonly id: number;
+  readonly replicaId?: ReplicaId;
+}
+
+/** Create a TextBuffer from initial text. */
+export interface FromStringRequest {
+  readonly type: "fromString";
+  readonly id: number;
+  readonly text: string;
+  readonly replicaId?: ReplicaId;
+}
+
+/** Insert text at a position. */
+export interface InsertRequest {
+  readonly type: "insert";
+  readonly id: number;
+  readonly offset: number;
+  readonly text: string;
+}
+
+/** Delete a range of text. */
+export interface DeleteRequest {
+  readonly type: "delete";
+  readonly id: number;
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Undo the last transaction. */
+export interface UndoRequest {
+  readonly type: "undo";
+  readonly id: number;
+}
+
+/** Redo the last undone transaction. */
+export interface RedoRequest {
+  readonly type: "redo";
+  readonly id: number;
+}
+
+/** Apply a remote operation. */
+export interface ApplyRemoteRequest {
+  readonly type: "applyRemote";
+  readonly id: number;
+  readonly operation: Operation;
+}
+
+/** Apply a batch of remote operations. */
+export interface ApplyRemoteBatchRequest {
+  readonly type: "applyRemoteBatch";
+  readonly id: number;
+  readonly operations: ReadonlyArray<Operation>;
+}
+
+/** Get the current text content. */
+export interface GetTextRequest {
+  readonly type: "getText";
+  readonly id: number;
+}
+
+/** Get the current document length. */
+export interface GetLengthRequest {
+  readonly type: "getLength";
+  readonly id: number;
+}
+
+/** Get the version vector. */
+export interface GetVersionRequest {
+  readonly type: "getVersion";
+  readonly id: number;
+}
+
+/** Set the undo group delay. */
+export interface SetGroupDelayRequest {
+  readonly type: "setGroupDelay";
+  readonly id: number;
+  readonly ms: number;
+}
+
+/** All possible request messages. */
+export type WorkerRequest =
+  | CreateRequest
+  | FromStringRequest
+  | InsertRequest
+  | DeleteRequest
+  | UndoRequest
+  | RedoRequest
+  | ApplyRemoteRequest
+  | ApplyRemoteBatchRequest
+  | GetTextRequest
+  | GetLengthRequest
+  | GetVersionRequest
+  | SetGroupDelayRequest;
+
+// ---------------------------------------------------------------------------
+// Response messages (worker → main thread)
+// ---------------------------------------------------------------------------
+
+/** Successful response with an operation (insert/delete/undo/redo). */
+export interface OperationResponse {
+  readonly type: "operation";
+  readonly id: number;
+  readonly operation: Operation | null;
+}
+
+/** Successful response with text content. */
+export interface TextResponse {
+  readonly type: "text";
+  readonly id: number;
+  readonly text: string;
+}
+
+/** Successful response with document length. */
+export interface LengthResponse {
+  readonly type: "length";
+  readonly id: number;
+  readonly length: number;
+}
+
+/** Successful response with version vector. */
+export interface VersionResponse {
+  readonly type: "version";
+  readonly id: number;
+  readonly version: VersionVector;
+}
+
+/** Acknowledgement for void operations. */
+export interface AckResponse {
+  readonly type: "ack";
+  readonly id: number;
+}
+
+/** Error response. */
+export interface ErrorResponse {
+  readonly type: "error";
+  readonly id: number;
+  readonly message: string;
+}
+
+/**
+ * Sync event pushed from the worker after any mutation.
+ * Contains the updated text snapshot so the main thread can re-render.
+ */
+export interface SyncEvent {
+  readonly type: "sync";
+  readonly text: string;
+  readonly length: number;
+}
+
+/** All possible response messages. */
+export type WorkerResponse =
+  | OperationResponse
+  | TextResponse
+  | LengthResponse
+  | VersionResponse
+  | AckResponse
+  | ErrorResponse
+  | SyncEvent;

--- a/src/worker/worker-text-buffer.test.ts
+++ b/src/worker/worker-text-buffer.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "bun:test";
+import { TextBuffer } from "../text/text-buffer.js";
+import { replicaId } from "../text/types.js";
+import { WorkerTextBuffer } from "./worker-text-buffer.js";
+
+const WORKER_URL = new URL("./crdt-worker.ts", import.meta.url).href;
+
+// ---------------------------------------------------------------------------
+// WorkerTextBuffer: creation
+// ---------------------------------------------------------------------------
+
+describe("WorkerTextBuffer creation", () => {
+  it("creates an empty buffer", async () => {
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    expect(buf.text).toBe("");
+    expect(buf.length).toBe(0);
+    buf.terminate();
+  });
+
+  it("creates a buffer from string", async () => {
+    const buf = await WorkerTextBuffer.fromString(WORKER_URL, "Hello, world!");
+    expect(buf.text).toBe("Hello, world!");
+    expect(buf.length).toBe(13);
+    buf.terminate();
+  });
+
+  it("creates a buffer with explicit replica ID", async () => {
+    const rid = replicaId(42);
+    const buf = await WorkerTextBuffer.create(WORKER_URL, rid);
+    expect(buf.text).toBe("");
+    buf.terminate();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkerTextBuffer: editing
+// ---------------------------------------------------------------------------
+
+describe("WorkerTextBuffer editing", () => {
+  it("inserts text", async () => {
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    const op = await buf.insert(0, "Hello");
+    expect(op).not.toBeNull();
+    expect(buf.text).toBe("Hello");
+    expect(buf.length).toBe(5);
+    buf.terminate();
+  });
+
+  it("inserts at different positions", async () => {
+    const buf = await WorkerTextBuffer.fromString(WORKER_URL, "Hello!");
+    await buf.insert(5, ", world");
+    expect(buf.text).toBe("Hello, world!");
+    buf.terminate();
+  });
+
+  it("deletes text", async () => {
+    const buf = await WorkerTextBuffer.fromString(WORKER_URL, "Hello, world!");
+    const op = await buf.delete(5, 12);
+    expect(op).not.toBeNull();
+    expect(buf.text).toBe("Hello!");
+    buf.terminate();
+  });
+
+  it("handles sequential edits", async () => {
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    await buf.insert(0, "abc");
+    await buf.insert(3, "def");
+    await buf.delete(1, 5);
+    expect(buf.text).toBe("af");
+    buf.terminate();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkerTextBuffer: getText round-trip
+// ---------------------------------------------------------------------------
+
+describe("WorkerTextBuffer getText", () => {
+  it("gets text via round-trip", async () => {
+    const buf = await WorkerTextBuffer.fromString(WORKER_URL, "test content");
+    const text = await buf.getText();
+    expect(text).toBe("test content");
+    buf.terminate();
+  });
+
+  it("gets length via round-trip", async () => {
+    const buf = await WorkerTextBuffer.fromString(WORKER_URL, "abcdef");
+    const len = await buf.getLength();
+    expect(len).toBe(6);
+    buf.terminate();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkerTextBuffer: sync callback
+// ---------------------------------------------------------------------------
+
+describe("WorkerTextBuffer sync", () => {
+  it("calls onSync after mutations", async () => {
+    const syncs: Array<{ text: string; length: number }> = [];
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    buf.onSync = (text, length) => {
+      syncs.push({ text, length });
+    };
+    await buf.insert(0, "Hello");
+    await buf.insert(5, " World");
+    // onSync is called via the sync event after each mutation,
+    // but by the time the operation promise resolves the sync
+    // has already been processed, so we can check state directly
+    expect(buf.text).toBe("Hello World");
+    expect(syncs.length).toBeGreaterThanOrEqual(1);
+    buf.terminate();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkerTextBuffer: collaboration
+// ---------------------------------------------------------------------------
+
+describe("WorkerTextBuffer collaboration", () => {
+  it("applies remote operations from another buffer", async () => {
+    // Create a local in-memory buffer to generate operations
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+    const local = TextBuffer.create(rid1);
+    const op1 = local.insert(0, "Hello");
+
+    // Create a worker buffer and apply the remote operation
+    const worker = await WorkerTextBuffer.create(WORKER_URL, rid2);
+    await worker.applyRemote(op1);
+    expect(worker.text).toBe("Hello");
+    worker.terminate();
+  });
+
+  it("applies batch of remote operations", async () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+    const local = TextBuffer.create(rid1);
+    const op1 = local.insert(0, "Hello");
+    const op2 = local.insert(5, " World");
+
+    const worker = await WorkerTextBuffer.create(WORKER_URL, rid2);
+    await worker.applyRemoteBatch([op1, op2]);
+    expect(worker.text).toBe("Hello World");
+    worker.terminate();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkerTextBuffer: undo/redo
+// ---------------------------------------------------------------------------
+
+describe("WorkerTextBuffer undo/redo", () => {
+  it("undoes an insert", async () => {
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    await buf.setGroupDelay(0);
+    await buf.insert(0, "Hello");
+    const undoOp = await buf.undo();
+    expect(undoOp).not.toBeNull();
+    expect(buf.text).toBe("");
+    buf.terminate();
+  });
+
+  it("redoes after undo", async () => {
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    await buf.setGroupDelay(0);
+    await buf.insert(0, "Hello");
+    await buf.undo();
+    const redoOp = await buf.redo();
+    expect(redoOp).not.toBeNull();
+    expect(buf.text).toBe("Hello");
+    buf.terminate();
+  });
+
+  it("returns null when nothing to undo", async () => {
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    const op = await buf.undo();
+    expect(op).toBeNull();
+    buf.terminate();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkerTextBuffer: error handling
+// ---------------------------------------------------------------------------
+
+describe("WorkerTextBuffer errors", () => {
+  it("rejects on terminate", async () => {
+    const buf = await WorkerTextBuffer.create(WORKER_URL);
+    buf.terminate();
+    await expect(buf.insert(0, "test")).rejects.toThrow("Worker terminated");
+  });
+});

--- a/src/worker/worker-text-buffer.ts
+++ b/src/worker/worker-text-buffer.ts
@@ -1,0 +1,217 @@
+/**
+ * WorkerTextBuffer: Main-thread proxy for the CRDT worker.
+ *
+ * Provides an async API that mirrors TextBuffer's interface, but all
+ * heavy CRDT operations run in a Web Worker. The main thread never blocks
+ * on CRDT computation.
+ *
+ * Sync events are pushed from the worker after every mutation, keeping the
+ * main thread's text snapshot up to date for rendering.
+ *
+ * @example
+ * ```ts
+ * import { WorkerTextBuffer } from "@iamnbutler/crdt/worker";
+ *
+ * const buffer = await WorkerTextBuffer.create(workerUrl);
+ * const op = await buffer.insert(0, "Hello");
+ * console.log(buffer.text); // "Hello" (from sync event)
+ * buffer.onSync = (text, length) => updateUI(text);
+ * buffer.terminate();
+ * ```
+ */
+
+import type { Operation, ReplicaId, VersionVector } from "../text/types.js";
+import type { WorkerRequest, WorkerResponse } from "./types.js";
+
+/** Callback invoked whenever the worker pushes a sync event. */
+export type SyncCallback = (text: string, length: number) => void;
+
+interface PendingRequest {
+  resolve: (response: WorkerResponse) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Main-thread client that proxies TextBuffer operations to a Web Worker.
+ *
+ * All mutation methods return Promises that resolve once the worker has
+ * processed the operation. A sync callback fires after every mutation
+ * with the updated text snapshot.
+ */
+export class WorkerTextBuffer {
+  private readonly worker: Worker;
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private terminated = false;
+
+  /** Current text snapshot, updated by sync events from the worker. */
+  text = "";
+
+  /** Current document length, updated by sync events from the worker. */
+  length = 0;
+
+  /** Optional callback invoked on every sync event from the worker. */
+  onSync: SyncCallback | null = null;
+
+  private constructor(worker: Worker) {
+    this.worker = worker;
+    this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      this.handleMessage(event.data);
+    };
+    this.worker.onerror = (event: ErrorEvent) => {
+      // Reject all pending requests on worker error
+      for (const [id, req] of this.pending) {
+        req.reject(new Error(`Worker error: ${event.message}`));
+        this.pending.delete(id);
+      }
+    };
+  }
+
+  /**
+   * Create a new WorkerTextBuffer with an empty document.
+   *
+   * @param workerOrUrl - A Worker instance or a URL/string to create one.
+   *   Browser: `new URL('./crdt-worker.js', import.meta.url)`
+   *   Bun: `new URL('./crdt-worker.ts', import.meta.url)`
+   */
+  static async create(
+    workerOrUrl: Worker | URL | string,
+    replicaId?: ReplicaId,
+  ): Promise<WorkerTextBuffer> {
+    const worker =
+      workerOrUrl instanceof Worker ? workerOrUrl : new Worker(workerOrUrl, { type: "module" });
+    const client = new WorkerTextBuffer(worker);
+    const request: WorkerRequest =
+      replicaId !== undefined ? { type: "create", id: 0, replicaId } : { type: "create", id: 0 };
+    await client.send(request);
+    return client;
+  }
+
+  /**
+   * Create a new WorkerTextBuffer initialized with text.
+   */
+  static async fromString(
+    workerOrUrl: Worker | URL | string,
+    text: string,
+    replicaId?: ReplicaId,
+  ): Promise<WorkerTextBuffer> {
+    const worker =
+      workerOrUrl instanceof Worker ? workerOrUrl : new Worker(workerOrUrl, { type: "module" });
+    const client = new WorkerTextBuffer(worker);
+    const request: WorkerRequest =
+      replicaId !== undefined
+        ? { type: "fromString", id: 0, text, replicaId }
+        : { type: "fromString", id: 0, text };
+    await client.send(request);
+    return client;
+  }
+
+  /** Insert text at a position. Returns the operation for broadcasting. */
+  async insert(offset: number, text: string): Promise<Operation | null> {
+    const response = await this.send({ type: "insert", id: 0, offset, text });
+    if (response.type === "operation") return response.operation;
+    return null;
+  }
+
+  /** Delete a range of text. Returns the operation for broadcasting. */
+  async delete(start: number, end: number): Promise<Operation | null> {
+    const response = await this.send({ type: "delete", id: 0, start, end });
+    if (response.type === "operation") return response.operation;
+    return null;
+  }
+
+  /** Undo the last transaction. Returns the operation or null. */
+  async undo(): Promise<Operation | null> {
+    const response = await this.send({ type: "undo", id: 0 });
+    if (response.type === "operation") return response.operation;
+    return null;
+  }
+
+  /** Redo the last undone transaction. Returns the operation or null. */
+  async redo(): Promise<Operation | null> {
+    const response = await this.send({ type: "redo", id: 0 });
+    if (response.type === "operation") return response.operation;
+    return null;
+  }
+
+  /** Apply a remote operation. */
+  async applyRemote(operation: Operation): Promise<void> {
+    await this.send({ type: "applyRemote", id: 0, operation });
+  }
+
+  /** Apply a batch of remote operations. */
+  async applyRemoteBatch(operations: ReadonlyArray<Operation>): Promise<void> {
+    await this.send({ type: "applyRemoteBatch", id: 0, operations });
+  }
+
+  /** Get the current text from the worker (round-trip). */
+  async getText(): Promise<string> {
+    const response = await this.send({ type: "getText", id: 0 });
+    if (response.type === "text") return response.text;
+    return this.text;
+  }
+
+  /** Get the current length from the worker (round-trip). */
+  async getLength(): Promise<number> {
+    const response = await this.send({ type: "getLength", id: 0 });
+    if (response.type === "length") return response.length;
+    return this.length;
+  }
+
+  /** Get the version vector from the worker. */
+  async getVersion(): Promise<VersionVector> {
+    const response = await this.send({ type: "getVersion", id: 0 });
+    if (response.type === "version") return response.version;
+    return new Map();
+  }
+
+  /** Set the undo group delay. */
+  async setGroupDelay(ms: number): Promise<void> {
+    await this.send({ type: "setGroupDelay", id: 0, ms });
+  }
+
+  /** Terminate the worker. No further operations are possible. */
+  terminate(): void {
+    this.terminated = true;
+    this.worker.terminate();
+    const pending = Array.from(this.pending.values());
+    this.pending.clear();
+    for (const req of pending) {
+      req.reject(new Error("Worker terminated"));
+    }
+  }
+
+  private send(request: WorkerRequest): Promise<WorkerResponse> {
+    if (this.terminated) {
+      return Promise.reject(new Error("Worker terminated"));
+    }
+    const id = this.nextId++;
+    const tagged = { ...request, id };
+    return new Promise<WorkerResponse>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.worker.postMessage(tagged);
+    });
+  }
+
+  private handleMessage(response: WorkerResponse): void {
+    // Sync events are broadcast, not tied to a request
+    if (response.type === "sync") {
+      this.text = response.text;
+      this.length = response.length;
+      if (this.onSync !== null) {
+        this.onSync(response.text, response.length);
+      }
+      return;
+    }
+
+    const req = this.pending.get(response.id);
+    if (req === undefined) return;
+    this.pending.delete(response.id);
+
+    if (response.type === "error") {
+      req.reject(new Error(response.message));
+    } else {
+      req.resolve(response);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the single-worker + postMessage spike from #122 — moves the entire CRDT into a Web Worker so the main thread never blocks on heavy merge/insert/delete operations.

- **`WorkerTextBuffer`** (main thread): async proxy that mirrors `TextBuffer`'s API — `insert()`, `delete()`, `undo()`, `redo()`, `applyRemote()`, `applyRemoteBatch()`, `getText()`, `getVersion()`
- **`crdt-worker.ts`** (worker thread): hosts the `TextBuffer`, processes commands via `postMessage`, pushes sync events with updated text snapshots
- **Protocol types**: strongly-typed request/response messages for all operations
- **Sync-before-response ordering**: sync events are sent before operation responses so `buffer.text` is always current when the promise resolves
- Exported as `@iamnbutler/crdt/worker` (client) and `@iamnbutler/crdt/worker/crdt-worker` (worker entry point)

### Architecture

```
Main Thread                     CRDT Worker
┌─────────────────┐             ┌─────────────────┐
│ WorkerTextBuffer │──request──►│  crdt-worker.ts  │
│                  │            │                  │
│  .text (snapshot)│◄──sync────│  TextBuffer      │
│  .onSync callback│◄──response│  (full CRDT state)│
└─────────────────┘             └─────────────────┘
```

## Test plan

- [x] 16 integration tests covering creation, editing, getText round-trip, sync callbacks, collaboration (applyRemote/batch), undo/redo, and error handling (terminate)
- [x] All 3982 existing tests still pass
- [x] TypeScript strict mode passes (no `any`, no assertions)
- [x] Biome lint/format clean

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)