### PR TITLE
perf: Float64 sort key encoding for faster Locator comparison

### DIFF
--- a/benchmarks/locator-encoding.ts
+++ b/benchmarks/locator-encoding.ts
@@ -1,0 +1,179 @@
+/**
+ * Benchmark: Float64 sort key encoding for Locator comparison.
+ *
+ * Measures the speedup from using precomputed Float64 sort keys vs
+ * full level-by-level comparison. Tests both comparison and sorting
+ * workloads across different locator depths and distributions.
+ *
+ * The "baseline" uses plain Locator objects without sortKey.
+ * The "optimized" uses createLocator which precomputes the sortKey.
+ */
+
+import { bench, group, run, summary } from "mitata";
+import { compareLocators, createLocator, locatorBetween } from "../src/text/locator.js";
+import type { Locator } from "../src/text/types.js";
+
+// ---------------------------------------------------------------------------
+// Test data generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Exact level-by-level comparison (baseline without sort key fast path).
+ * This is a copy of the original compareLocators before the optimization.
+ */
+function compareLocatorsBaseline(a: Locator, b: Locator): number {
+  const minLen = Math.min(a.levels.length, b.levels.length);
+  for (let i = 0; i < minLen; i++) {
+    const aLevel = a.levels[i];
+    const bLevel = b.levels[i];
+    if (aLevel !== undefined && bLevel !== undefined && aLevel !== bLevel) {
+      return aLevel - bLevel;
+    }
+  }
+  return a.levels.length - b.levels.length;
+}
+
+/** Generate N sequential locators using locatorBetween (realistic distribution). */
+function generateSequentialLocators(n: number): Locator[] {
+  const locators: Locator[] = [];
+  const min: Locator = { levels: [0] };
+  const max: Locator = { levels: [Number.MAX_SAFE_INTEGER] };
+
+  let prev = locatorBetween(min, max);
+  locators.push(prev);
+
+  for (let i = 1; i < n; i++) {
+    const next = locatorBetween(prev, max);
+    locators.push(next);
+    prev = next;
+  }
+  return locators;
+}
+
+/** Generate N random locators with varying depths (1-3 levels). */
+function generateMixedDepthLocators(n: number): Locator[] {
+  const locators: Locator[] = [];
+  for (let i = 0; i < n; i++) {
+    const depth = 1 + Math.floor(Math.random() * 3);
+    const levels: number[] = [];
+    for (let d = 0; d < depth; d++) {
+      if (d === 0) {
+        levels.push(Math.floor(Math.random() * 65535));
+      } else {
+        levels.push(Math.floor(Math.random() * 100000));
+      }
+    }
+    locators.push(createLocator(levels));
+  }
+  return locators;
+}
+
+/** Strip sort keys from locators to create baseline versions. */
+function stripSortKeys(locators: Locator[]): Locator[] {
+  return locators.map((l) => ({ levels: l.levels }));
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+const N = 10_000;
+
+// Sequential locators (from locatorBetween — already have sort keys)
+const sequentialWithKeys = generateSequentialLocators(N);
+const sequentialNoKeys = stripSortKeys(sequentialWithKeys);
+
+// Mixed depth locators
+const mixedWithKeys = generateMixedDepthLocators(N);
+const mixedNoKeys = stripSortKeys(mixedWithKeys);
+
+// Comparison benchmarks: 10K adjacent pair comparisons
+summary(() => {
+  group("Compare 10K adjacent pairs (sequential locators)", () => {
+    bench("baseline (no sort key)", () => {
+      let sum = 0;
+      for (let i = 0; i < N - 1; i++) {
+        const a = sequentialNoKeys[i];
+        const b = sequentialNoKeys[i + 1];
+        if (a !== undefined && b !== undefined) {
+          sum += compareLocatorsBaseline(a, b);
+        }
+      }
+      return sum;
+    });
+
+    bench("optimized (Float64 sort key)", () => {
+      let sum = 0;
+      for (let i = 0; i < N - 1; i++) {
+        const a = sequentialWithKeys[i];
+        const b = sequentialWithKeys[i + 1];
+        if (a !== undefined && b !== undefined) {
+          sum += compareLocators(a, b);
+        }
+      }
+      return sum;
+    });
+  });
+});
+
+summary(() => {
+  group("Compare 10K adjacent pairs (mixed depth locators)", () => {
+    bench("baseline (no sort key)", () => {
+      let sum = 0;
+      for (let i = 0; i < N - 1; i++) {
+        const a = mixedNoKeys[i];
+        const b = mixedNoKeys[i + 1];
+        if (a !== undefined && b !== undefined) {
+          sum += compareLocatorsBaseline(a, b);
+        }
+      }
+      return sum;
+    });
+
+    bench("optimized (Float64 sort key)", () => {
+      let sum = 0;
+      for (let i = 0; i < N - 1; i++) {
+        const a = mixedWithKeys[i];
+        const b = mixedWithKeys[i + 1];
+        if (a !== undefined && b !== undefined) {
+          sum += compareLocators(a, b);
+        }
+      }
+      return sum;
+    });
+  });
+});
+
+// Sorting benchmarks
+summary(() => {
+  group("Sort 10K locators (sequential)", () => {
+    bench("baseline (no sort key)", () => {
+      const arr = [...sequentialNoKeys];
+      arr.sort(compareLocatorsBaseline);
+    });
+
+    bench("optimized (Float64 sort key)", () => {
+      const arr = [...sequentialWithKeys];
+      arr.sort(compareLocators);
+    });
+  });
+});
+
+summary(() => {
+  group("Sort 10K locators (shuffled mixed depth)", () => {
+    const shuffledWithKeys = [...mixedWithKeys].sort(() => Math.random() - 0.5);
+    const shuffledNoKeys = [...mixedNoKeys].sort(() => Math.random() - 0.5);
+
+    bench("baseline (no sort key)", () => {
+      const arr = [...shuffledNoKeys];
+      arr.sort(compareLocatorsBaseline);
+    });
+
+    bench("optimized (Float64 sort key)", () => {
+      const arr = [...shuffledWithKeys];
+      arr.sort(compareLocators);
+    });
+  });
+});
+
+await run();

--- a/scripts/record-benchmarks.ts
+++ b/scripts/record-benchmarks.ts
@@ -337,11 +337,14 @@ async function main() {
             if (!existsSync(join(worktree, RESULTS_DIR))) {
               mkdirSync(join(worktree, RESULTS_DIR), { recursive: true });
             }
-            writeFileSync(join(worktree, RESULTS_DIR, `${gitInfo.sha}.json`), JSON.stringify(run, null, 2));
+            writeFileSync(
+              join(worktree, RESULTS_DIR, `${gitInfo.sha}.json`),
+              JSON.stringify(run, null, 2),
+            );
 
             // Reload and update index
             const freshIndex: Index = JSON.parse(readFileSync(indexPath, "utf-8"));
-            if (!freshIndex.runs.some(r => r.sha === gitInfo.sha)) {
+            if (!freshIndex.runs.some((r) => r.sha === gitInfo.sha)) {
               freshIndex.runs.unshift({
                 sha: gitInfo.sha,
                 shortSha: gitInfo.shortSha,
@@ -353,7 +356,9 @@ async function main() {
             }
 
             exec("git add .", { cwd: worktree });
-            exec(`git commit -m "Add benchmark results for ${gitInfo.shortSha}"`, { cwd: worktree });
+            exec(`git commit -m "Add benchmark results for ${gitInfo.shortSha}"`, {
+              cwd: worktree,
+            });
           }
 
           exec(`git push origin ${BRANCH}`, { cwd: worktree });

--- a/src/protocol/state-sync.ts
+++ b/src/protocol/state-sync.ts
@@ -9,6 +9,7 @@
 
 import { cloneVersionVector } from "../text/clock.js";
 import { createFragment } from "../text/fragment.js";
+import { createLocator } from "../text/locator.js";
 import type { Fragment, OperationId, ReplicaId, VersionVector } from "../text/types.js";
 import { BINARY_VERSION, type SerializedFragment, type StateSnapshot } from "./types.js";
 
@@ -84,11 +85,11 @@ export function applySnapshot(snapshot: StateSnapshot): ApplySnapshotResult {
     const fragment = createFragment(
       serialized.insertionId,
       serialized.insertionOffset,
-      { levels: [...serialized.locatorLevels] },
+      createLocator([...serialized.locatorLevels]),
       serialized.text,
       serialized.visible,
       [...serialized.deletions],
-      { levels: [...serialized.baseLocatorLevels] },
+      createLocator([...serialized.baseLocatorLevels]),
     );
     fragments.push(fragment);
   }

--- a/src/text/fragment.ts
+++ b/src/text/fragment.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Dimension, Summary } from "../sum-tree/index.js";
-import { MIN_LOCATOR, compareLocators } from "./locator.js";
+import { MIN_LOCATOR, compareLocators, createLocator } from "./locator.js";
 import { MIN_OPERATION_ID, compareOperationIds } from "./types.js";
 import type { Fragment, FragmentSummary, Locator, OperationId } from "./types.js";
 
@@ -222,9 +222,7 @@ export function splitFragment(fragment: Fragment, localOffset: number): [Fragmen
 
   // Left: [...baseLocator, 2*insertionOffset]
   const leftInsertionOffset = fragment.insertionOffset;
-  const leftLocator: Locator = {
-    levels: [...parentLocator.levels, 2 * leftInsertionOffset],
-  };
+  const leftLocator: Locator = createLocator([...parentLocator.levels, 2 * leftInsertionOffset]);
 
   const left = createFragment(
     fragment.insertionId,
@@ -238,9 +236,7 @@ export function splitFragment(fragment: Fragment, localOffset: number): [Fragmen
 
   // Right: [...baseLocator, 2*insertionOffset] for the right part
   const rightInsertionOffset = fragment.insertionOffset + localOffset;
-  const rightLocator: Locator = {
-    levels: [...parentLocator.levels, 2 * rightInsertionOffset],
-  };
+  const rightLocator: Locator = createLocator([...parentLocator.levels, 2 * rightInsertionOffset]);
 
   const right = createFragment(
     fragment.insertionId,

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -52,6 +52,8 @@ export {
   MIN_LOCATOR,
   MAX_LOCATOR,
   compareLocators,
+  computeSortKey,
+  createLocator,
   locatorBetween,
   locatorsEqual,
 } from "./locator.js";

--- a/src/text/locator.ts
+++ b/src/text/locator.ts
@@ -14,6 +14,64 @@ import type { Locator } from "./types.js";
 // 2^53 - 1 is Number.MAX_SAFE_INTEGER (the max integer a JS number can represent exactly)
 const MAX_VALUE = Number.MAX_SAFE_INTEGER;
 
+// ---------------------------------------------------------------------------
+// Float64 sort key encoding
+// ---------------------------------------------------------------------------
+//
+// Packs the first 3 levels of a Locator into a single Float64 number for
+// fast comparison. Layout (52 bits of mantissa):
+//   Level 0: 16 bits (max 65535) — matches the FIRST_LEVEL_SHIFT constraint
+//   Level 1: 18 bits (max 262143) — covers most split/insert offsets
+//   Level 2: 18 bits (max 262143)
+//
+// When a level value exceeds its encodable range, the sort key is set to
+// the sentinel value -1 ("no sort key"). This forces fallback to exact
+// comparison, avoiding incorrect ordering from clamped values.
+
+/** Bit widths for each encoded level. */
+const SORT_KEY_L1_SHIFT = 18;
+const SORT_KEY_L0_SHIFT = 36; // 18 + 18
+const SORT_KEY_L1_MAX = 262143; // (1 << 18) - 1
+const SORT_KEY_L0_MAX = 65535; // (1 << 16) - 1
+
+/** Sentinel indicating the sort key could not be computed (overflow). */
+const SORT_KEY_OVERFLOW = -1;
+
+// Precomputed constants to avoid repeated exponentiation in hot paths
+const L0_MULTIPLIER = 2 ** SORT_KEY_L0_SHIFT; // 2^36
+const L1_MULTIPLIER = 2 ** SORT_KEY_L1_SHIFT; // 2^18
+
+/**
+ * Compute a Float64 sort key from a Locator's levels.
+ *
+ * Returns a non-negative number that preserves lexicographic ordering for
+ * locators whose first 3 levels fit within the bit-width limits. Returns
+ * SORT_KEY_OVERFLOW (-1) if any level exceeds its range, forcing fallback
+ * to exact comparison.
+ *
+ * Locators with > 3 levels that share the same first 3 levels produce the
+ * same sort key (a safe tie resolved by exact comparison).
+ */
+export function computeSortKey(levels: ReadonlyArray<number>): number {
+  const l0 = levels[0] ?? 0;
+  if (l0 > SORT_KEY_L0_MAX) return SORT_KEY_OVERFLOW;
+
+  const l1 = levels.length > 1 ? (levels[1] ?? 0) : 0;
+  if (l1 > SORT_KEY_L1_MAX) return SORT_KEY_OVERFLOW;
+
+  const l2 = levels.length > 2 ? (levels[2] ?? 0) : 0;
+  if (l2 > SORT_KEY_L1_MAX) return SORT_KEY_OVERFLOW;
+
+  return l0 * L0_MULTIPLIER + l1 * L1_MULTIPLIER + l2;
+}
+
+/**
+ * Create a Locator with a precomputed sort key.
+ */
+export function createLocator(levels: ReadonlyArray<number>): Locator {
+  return { levels, sortKey: computeSortKey(levels) };
+}
+
 // The right-shift for the first element: leave room for sequential insertions.
 // >> 37 means the midpoint of the first level is ~2^15 = 32768.
 const FIRST_LEVEL_SHIFT = 37;
@@ -22,16 +80,39 @@ const FIRST_LEVEL_SHIFT = 37;
 const MAX_DEPTH = 16;
 
 /** The minimum Locator — sorts before all others. */
-export const MIN_LOCATOR: Locator = { levels: [0] };
+export const MIN_LOCATOR: Locator = createLocator([0]);
 
 /** The maximum Locator — sorts after all others. */
-export const MAX_LOCATOR: Locator = { levels: [MAX_VALUE] };
+export const MAX_LOCATOR: Locator = createLocator([MAX_VALUE]);
 
 /**
  * Lexicographic comparison of two Locators.
  * Returns <0 if a < b, 0 if a === b, >0 if a > b.
+ *
+ * Uses a Float64 sort key as a fast path: if the sort keys differ, the
+ * comparison is a single number subtraction. Falls through to exact
+ * level-by-level comparison only when sort keys tie (rare in practice:
+ * deep locators, large level values, or trailing-zero differences).
  */
 export function compareLocators(a: Locator, b: Locator): number {
+  // Fast path: compare precomputed Float64 sort keys.
+  // Only use when both are present and valid (>= 0). Overflow (-1) or
+  // undefined means we must use exact comparison.
+  const ka = a.sortKey;
+  const kb = b.sortKey;
+  if (ka !== undefined && kb !== undefined && ka >= 0 && kb >= 0 && ka !== kb) {
+    return ka - kb;
+  }
+
+  // Slow path: exact level-by-level comparison (sort keys tied)
+  return compareLocatorsExact(a, b);
+}
+
+/**
+ * Exact level-by-level lexicographic comparison. Used as fallback when
+ * Float64 sort keys are equal.
+ */
+function compareLocatorsExact(a: Locator, b: Locator): number {
   const minLen = Math.min(a.levels.length, b.levels.length);
   for (let i = 0; i < minLen; i++) {
     const aLevel = a.levels[i];
@@ -93,7 +174,7 @@ export function locatorBetween(left: Locator, right: Locator): Locator {
           if (levels.length < MAX_DEPTH) {
             levels.push(MAX_VALUE - 1);
           }
-          return { levels };
+          return createLocator(levels);
         }
         // rightNextVal is 0, need to go even deeper - continue the loop
       }
@@ -104,7 +185,7 @@ export function locatorBetween(left: Locator, right: Locator): Locator {
     if (i === 0 && rv - lv > 1) {
       const mid = lv + Math.floor((rv - lv) / 2);
       levels.push(mid);
-      return { levels };
+      return createLocator(levels);
     }
 
     // At level >= 1: go deeper to avoid collision with inside-inserts and splits.
@@ -173,7 +254,7 @@ export function locatorBetween(left: Locator, right: Locator): Locator {
         }
       }
     }
-    return { levels };
+    return createLocator(levels);
   }
 
   // Fallback: extend with a midpoint at the next level
@@ -182,7 +263,7 @@ export function locatorBetween(left: Locator, right: Locator): Locator {
     levels.push(Math.floor(nextMax / 2));
   }
 
-  return { levels };
+  return createLocator(levels);
 }
 
 /**

--- a/src/text/serialization.ts
+++ b/src/text/serialization.ts
@@ -12,6 +12,7 @@
  * - Applied operations set (for idempotency)
  */
 
+import { createLocator } from "./locator.js";
 import type { Fragment, Locator, OperationId, ReplicaId, TransactionId } from "./types.js";
 import { replicaId, transactionId } from "./types.js";
 
@@ -118,7 +119,7 @@ export function serializeLocator(loc: Locator): SerializedLocator {
 
 /** Deserialize a Locator. */
 export function deserializeLocator(s: SerializedLocator): Locator {
-  return { levels: [...s.l] };
+  return createLocator([...s.l]);
 }
 
 /** Serialize a Fragment (without the summary method). */

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -28,7 +28,13 @@ import {
   visibleLenDimension,
   withVisibility,
 } from "./fragment.js";
-import { MAX_LOCATOR, MIN_LOCATOR, compareLocators, locatorBetween } from "./locator.js";
+import {
+  MAX_LOCATOR,
+  MIN_LOCATOR,
+  compareLocators,
+  createLocator,
+  locatorBetween,
+} from "./locator.js";
 import {
   SERIALIZATION_VERSION,
   type SerializedSnapshot,
@@ -893,12 +899,10 @@ export class TextBuffer {
             // This happens when the current fragment is an inside-insert at the same slot.
             let insertLocator: Locator | undefined = undefined;
             if (prevFrag !== undefined) {
-              const candidateInsertLocator: Locator = {
-                levels: [
-                  ...prevFrag.baseLocator.levels,
-                  2 * (prevFrag.insertionOffset + prevFrag.length) - 1,
-                ],
-              };
+              const candidateInsertLocator: Locator = createLocator([
+                ...prevFrag.baseLocator.levels,
+                2 * (prevFrag.insertionOffset + prevFrag.length) - 1,
+              ]);
               const candidateCmp = compareLocators(candidateInsertLocator, rightLocator);
               // Only use the candidate if it's strictly less than rightLocator
               insertLocator = candidateCmp < 0 ? candidateInsertLocator : undefined;
@@ -926,9 +930,7 @@ export class TextBuffer {
           // Compute explicit Locator using the 2*k-1 scheme to avoid collisions
           // with the 2*k scheme used for split fragments
           const k = right.insertionOffset;
-          const insertLocator: Locator = {
-            levels: [...frag.baseLocator.levels, 2 * k - 1],
-          };
+          const insertLocator: Locator = createLocator([...frag.baseLocator.levels, 2 * k - 1]);
 
           return {
             leftLocator: left.locator,
@@ -963,9 +965,10 @@ export class TextBuffer {
           // fragment due to operation ID tie-breaking. Instead, we use
           // locatorBetween to find a locator that sorts BEFORE the next fragment.
           const k = frag.insertionOffset + frag.length;
-          const candidateInsertLocator: Locator = {
-            levels: [...frag.baseLocator.levels, 2 * k - 1],
-          };
+          const candidateInsertLocator: Locator = createLocator([
+            ...frag.baseLocator.levels,
+            2 * k - 1,
+          ]);
 
           const leftLocator = frag.locator;
           const rightLocator =
@@ -1005,12 +1008,10 @@ export class TextBuffer {
     // Compute insertLocator from the last fragment's end position
     const insertLocator =
       lastFrag !== undefined
-        ? {
-            levels: [
-              ...lastFrag.baseLocator.levels,
-              2 * (lastFrag.insertionOffset + lastFrag.length) - 1,
-            ],
-          }
+        ? createLocator([
+            ...lastFrag.baseLocator.levels,
+            2 * (lastFrag.insertionOffset + lastFrag.length) - 1,
+          ])
         : undefined;
     return {
       leftLocator: lastFrag !== undefined ? lastFrag.locator : MIN_LOCATOR,
@@ -1051,9 +1052,7 @@ export class TextBuffer {
         return {
           leftLocator: lastFrag.locator,
           rightLocator: MAX_LOCATOR,
-          insertLocator: {
-            levels: [...lastFrag.baseLocator.levels, 2 * k - 1],
-          },
+          insertLocator: createLocator([...lastFrag.baseLocator.levels, 2 * k - 1]),
           afterRef: {
             insertionId: lastFrag.insertionId,
             offset: k,
@@ -1119,12 +1118,10 @@ export class TextBuffer {
       // because there's no room between a locator and its immediate child.
       let insertLocator: Locator | undefined = undefined;
       if (prevFrag) {
-        const candidateInsertLocator: Locator = {
-          levels: [
-            ...prevFrag.baseLocator.levels,
-            2 * (prevFrag.insertionOffset + prevFrag.length) - 1,
-          ],
-        };
+        const candidateInsertLocator: Locator = createLocator([
+          ...prevFrag.baseLocator.levels,
+          2 * (prevFrag.insertionOffset + prevFrag.length) - 1,
+        ]);
         const candidateCmp = compareLocators(candidateInsertLocator, currentFrag.locator);
         // Check if candidate is a prefix of rightLocator
         const isPrefix =
@@ -1163,9 +1160,10 @@ export class TextBuffer {
       // Compute insertLocator from current fragment's end position
       // IMPORTANT: Check for collision with rightLocator (nextFrag?.locator)
       const k = currentFrag.insertionOffset + currentFrag.length;
-      const candidateInsertLocator: Locator = {
-        levels: [...currentFrag.baseLocator.levels, 2 * k - 1],
-      };
+      const candidateInsertLocator: Locator = createLocator([
+        ...currentFrag.baseLocator.levels,
+        2 * k - 1,
+      ]);
       const candidateCmp =
         rightLocator !== MAX_LOCATOR ? compareLocators(candidateInsertLocator, rightLocator) : -1;
       const insertLocator = candidateCmp < 0 ? candidateInsertLocator : undefined;

--- a/src/text/types.ts
+++ b/src/text/types.ts
@@ -78,6 +78,15 @@ export const MAX_OPERATION_ID: OperationId = {
  */
 export interface Locator {
   readonly levels: ReadonlyArray<number>;
+  /**
+   * Precomputed Float64 sort key for fast comparison. Encodes the first 3
+   * levels into a single number (52-bit mantissa). When present, enables
+   * single-instruction comparisons for the common case.
+   *
+   * Set to -1 if any level exceeds the encodable range (overflow sentinel).
+   * Undefined if not yet computed (falls through to exact comparison).
+   */
+  readonly sortKey?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a precomputed Float64 sort key to the `Locator` interface that encodes the first 3 levels into a single number (52-bit mantissa: 16 + 18 + 18 bits)
- `compareLocators()` uses the sort key as a fast path — resolves most comparisons with a single number subtraction instead of iterating through levels
- Introduces `createLocator(levels)` helper used at all Locator creation sites to precompute the sort key at construction time
- Overflow sentinel (-1) ensures correctness when level values exceed the encodable range, falling back to exact level-by-level comparison

## Benchmark Results (10K locators)

| Workload | Speedup |
|----------|---------|
| Mixed depth comparison | **1.74x faster** |
| Sequential sort | **1.53x faster** |
| Mixed depth sort | **1.34x faster** |
| Sequential comparison | ~1x (already fast, depth-1 resolves on first level) |

## Design Decisions

- **No WeakMap cache**: Initial prototype used WeakMap for sort key caching, but JSC (Bun) WeakMap overhead made it slower than baseline. Storing the sort key directly on the Locator object gives zero-cost property access.
- **Overflow sentinel (-1)**: When any level exceeds its bit range (e.g., `MAX_LOCATOR` with level 0 = MAX_SAFE_INTEGER), the sort key is -1 and comparison falls through to the exact path. This avoids incorrect ordering from clamped values.
- **Backward compatible**: Locators without `sortKey` (e.g., from tests using plain `{ levels: [...] }`) gracefully fall through to exact comparison.

## Test plan

- [x] All 3966 existing tests pass
- [x] TypeScript strict mode passes
- [x] Biome lint passes
- [x] Locator encoding benchmark added (`benchmarks/locator-encoding.ts`)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)