### PR TITLE
bench: add 10K fragment bulk sort benchmark

### DIFF
--- a/benchmarks/text-buffer.ts
+++ b/benchmarks/text-buffer.ts
@@ -12,7 +12,8 @@
  */
 
 import { bench, group, run } from "mitata";
-import { TextBuffer } from "../src/text/index.js";
+import { TextBuffer, sortFragments } from "../src/text/index.js";
+import type { Fragment } from "../src/text/index.js";
 import { loadEditingTrace } from "./fixtures.js";
 import { type DocumentSize, generateSyntheticDocument } from "./synthetic.js";
 
@@ -321,6 +322,56 @@ group("text-apply-remote", () => {
     }
     return target;
   });
+});
+
+// ---------------------------------------------------------------------------
+// Fragment Bulk Sort
+// ---------------------------------------------------------------------------
+
+// Build a fragmented buffer with `count` fragments via single-char inserts.
+// Each single-char insert creates exactly one fragment. Inserts at the end
+// are fast and produce fragments with distinct locators for sort benchmarking.
+function createFragmentedBuffer(count: number): TextBuffer {
+  const buf = TextBuffer.create("replica-0");
+  for (let i = 0; i < count; i++) {
+    buf.insert(buf.length, String.fromCharCode(97 + (i % 26)));
+  }
+  return buf;
+}
+
+const fragmentCounts = [1_000, 10_000, 50_000];
+
+console.log("Generating fragmented buffers for sort benchmarks...");
+const fragmentedBuffers: Record<number, { buf: TextBuffer; frags: Fragment[] }> = {};
+for (const count of fragmentCounts) {
+  const buf = createFragmentedBuffer(count);
+  const frags = buf.getFragments();
+  fragmentedBuffers[count] = { buf, frags };
+  console.log(`  ${count.toLocaleString()} target → ${frags.length.toLocaleString()} fragments`);
+}
+console.log("Fragmented buffers ready.\n");
+
+group("fragment-bulk-sort", () => {
+  for (const count of fragmentCounts) {
+    const entry = fragmentedBuffers[count];
+    if (entry === undefined) continue;
+    const label = count >= 1000 ? `${count / 1000}K` : `${count}`;
+
+    // Benchmark raw Array.sort() with the comparator
+    bench(`raw sort (${label} fragments)`, () => {
+      const copy = entry.frags.slice();
+      sortFragments(copy);
+      return copy;
+    });
+
+    // Benchmark sort + tree rebuild (sortFragments + setFragments)
+    bench(`sort + tree rebuild (${label} fragments)`, () => {
+      const copy = entry.frags.slice();
+      sortFragments(copy);
+      entry.buf.rebuildFromFragments(copy);
+      return entry.buf;
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -84,7 +84,7 @@ export {
 } from "./fragment.js";
 
 // TextBuffer
-export { TextBuffer } from "./text-buffer.js";
+export { TextBuffer, sortFragments } from "./text-buffer.js";
 
 // Snapshot
 export { TextBufferSnapshot } from "./snapshot.js";

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -98,7 +98,7 @@ function compareLocatorsForSort(a: Locator, b: Locator): number {
  * 2. Split parts of the same operation sort by offset
  * 3. Child locators sort after parent locators with lower operation IDs
  */
-function sortFragments(frags: Fragment[]): void {
+export function sortFragments(frags: Fragment[]): void {
   frags.sort((a, b) => {
     // First, compare by locator prefix
     const locCmp = compareLocatorsForSort(a.locator, b.locator);
@@ -1906,6 +1906,16 @@ export class TextBuffer {
   /** Get all fragments as an array. */
   private fragmentsArray(): Fragment[] {
     return this.fragments.toArray();
+  }
+
+  /** Get all fragments as an array (public, for benchmarking/analysis). */
+  getFragments(): Fragment[] {
+    return this.fragments.toArray();
+  }
+
+  /** Rebuild the buffer from a sorted fragment array (public, for benchmarking/analysis). */
+  rebuildFromFragments(frags: Fragment[]): void {
+    this.setFragments(frags);
   }
 
   /** Check if an operation has already been applied. O(1) numeric lookup. */


### PR DESCRIPTION
## Summary
- Adds a "Fragment Bulk Sort" benchmark group to `benchmarks/text-buffer.ts` with 1K, 10K, and 50K fragment variants
- Benchmarks both raw `Array.sort()` with the locator comparator and the full `sortFragments()` + `setFragments()` (tree rebuild) path
- Exports `sortFragments` and adds `getFragments()`/`rebuildFromFragments()` public methods on `TextBuffer` to enable isolated sort benchmarking

## Baseline results (arm64)
| Fragments | Raw sort | Sort + tree rebuild |
|-----------|----------|---------------------|
| 1K | ~19µs | ~84µs |
| 10K | ~198µs | ~989µs |
| 50K | ~1.0ms | ~5.8ms |

## Test plan
- [x] All 3677 existing tests pass
- [x] TypeScript type-checks cleanly
- [x] Benchmark runs successfully with all 6 variants
- [ ] CI benchmark suite completes without regression alerts

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)