### PR TITLE
fix: add release guard to lines() and chunks() on TextBufferSnapshot

### DIFF
--- a/src/text/snapshot.test.ts
+++ b/src/text/snapshot.test.ts
@@ -115,6 +115,16 @@ describe("TextBufferSnapshot", () => {
       expect(() => snapshot.lineCount).toThrow("Cannot use released snapshot");
     });
 
+    test("release() prevents iteration via lines() and chunks()", () => {
+      const buffer = TextBuffer.fromString("alpha\nbeta");
+      const snapshot = buffer.snapshot();
+
+      snapshot.release();
+
+      expect(() => [...snapshot.lines()]).toThrow("Cannot use released snapshot");
+      expect(() => [...snapshot.chunks()]).toThrow("Cannot use released snapshot");
+    });
+
     test("release() is idempotent", () => {
       const buffer = TextBuffer.fromString("test");
       const snapshot = buffer.snapshot();

--- a/src/text/snapshot.ts
+++ b/src/text/snapshot.ts
@@ -406,6 +406,7 @@ export class TextBufferSnapshot implements DocumentSnapshot {
    * ```
    */
   *lines(startLine?: number, endLine?: number): IterableIterator<string> {
+    this.checkReleased();
     yield* this.getRope().lines(startLine, endLine);
   }
 
@@ -426,6 +427,7 @@ export class TextBufferSnapshot implements DocumentSnapshot {
    * ```
    */
   *chunks(start?: number, end?: number): IterableIterator<string> {
+    this.checkReleased();
     yield* this.getRope().chunks(start, end);
   }
 


### PR DESCRIPTION
## Summary

- `TextBufferSnapshot.lines()` and `.chunks()` bypassed the `checkReleased()` guard, allowing released snapshots to silently serve stale data while every other read path correctly threw `Cannot use released snapshot`
- Added `this.checkReleased()` calls to both generator methods, matching the existing guard pattern
- Added regression test covering both methods after release

Closes #349

## Test plan

- [x] `bun test src/text/snapshot.test.ts` — 24 pass / 0 fail
- [x] Verified new test fails without the fix, passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)