### PR TITLE
bench: add fragment bulk sort baseline (1K/10K/50K)

### DIFF
--- a/benchmarks/text-buffer.ts
+++ b/benchmarks/text-buffer.ts
@@ -12,7 +12,8 @@
  */
 
 import { bench, group, run } from "mitata";
-import { TextBuffer } from "../src/text/index.js";
+import type { Fragment } from "../src/text/index.js";
+import { TextBuffer, replicaId, sortFragments } from "../src/text/index.js";
 import { loadEditingTrace } from "./fixtures.js";
 import { type DocumentSize, generateSyntheticDocument } from "./synthetic.js";
 
@@ -321,6 +322,154 @@ group("text-apply-remote", () => {
     }
     return target;
   });
+});
+
+// ---------------------------------------------------------------------------
+// Fragment Bulk Sort
+//
+// Baseline for bulk fragment sorting (see issue #187). Whenever a split or a
+// remote insert forces a canonical re-order, TextBuffer runs
+// `sortFragments()` (Array.sort with `compareFragmentsForSort`) over the whole
+// fragment list and then `setFragments()`, which rebuilds the SumTree
+// (`SumTree.fromItems`) *and* the `_fragmentIds` index. These benchmarks
+// isolate those three costs so alternative sorting strategies have something
+// concrete to beat.
+//
+// The comparator walks locator levels, so its cost scales with locator depth,
+// not just fragment count. The corpora below are built by real editing so the
+// depth distribution is representative (~6 levels at 1K, ~12 at 50K).
+//
+// Baseline as of 2026-08, bun 1.3.14 on arm64-linux @ ~3 GHz (avg/iter):
+//
+//   frags | sort (sorted) | sort (shuffled) | rebuild only | sort + rebuild
+//   ------|---------------|-----------------|--------------|---------------
+//     1K  |      37.5 us  |         315 us  |      120 us  |        462 us
+//    10K  |      1.10 ms  |        7.94 ms  |     3.39 ms  |       12.2 ms
+//    50K  |      18.8 ms  |         111 ms  |     45.2 ms  |        156 ms
+//
+// So the headline number for #117: sorting 10K fragments from scratch costs
+// ~8 ms, and the tree rebuild that follows adds ~3 ms on top.
+// ---------------------------------------------------------------------------
+
+/** Deterministic PRNG so corpora are identical across runs. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Build a maximally fragmented fragment list in canonical order.
+ *
+ * Models `replicas` peers editing offline and then merging: each peer performs
+ * single-character inserts at random offsets (every insert yields one
+ * fragment), and the merged state is the concatenation of every peer's
+ * fragments in canonical order. Peers that never synced produce overlapping
+ * locators, so the merged list also exercises the comparator's operation-ID
+ * tie-break — roughly a quarter of adjacent pairs share a locator.
+ *
+ * Building each peer separately is also what keeps setup affordable: local
+ * inserts get more expensive as a buffer grows, so four buffers of n/4
+ * fragments cost far less than one buffer of n.
+ */
+function buildFragmentCorpus(count: number, replicas: number): Fragment[] {
+  const frags: Fragment[] = [];
+
+  for (let r = 0; r < replicas; r++) {
+    const rand = mulberry32(0x5eed + r * 7919);
+    const buf = TextBuffer.create(replicaId(r + 1));
+    const share = Math.floor(count / replicas) + (r < count % replicas ? 1 : 0);
+
+    for (let i = 0; i < share; i++) {
+      const pos = buf.length === 0 ? 0 : Math.floor(rand() * (buf.length + 1));
+      buf.insert(pos, "x");
+    }
+
+    frags.push(...buf.fragmentList());
+  }
+
+  sortFragments(frags);
+  return frags;
+}
+
+/** Fisher-Yates shuffle with a fixed seed. */
+function shuffled(frags: Fragment[]): Fragment[] {
+  const out = [...frags];
+  const rand = mulberry32(0xd1ce);
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    const a = out[i];
+    const b = out[j];
+    if (a !== undefined && b !== undefined) {
+      out[i] = b;
+      out[j] = a;
+    }
+  }
+  return out;
+}
+
+const fragmentCounts = [1_000, 10_000, 50_000];
+
+console.log("Building fragment corpora for bulk sort benchmarks...");
+const corpora = new Map<number, { canonical: Fragment[]; scrambled: Fragment[] }>();
+for (const count of fragmentCounts) {
+  const canonical = buildFragmentCorpus(count, 4);
+  corpora.set(count, { canonical, scrambled: shuffled(canonical) });
+  console.log(`  ${count.toLocaleString()} fragments ready`);
+}
+console.log("Fragment corpora ready.\n");
+
+group("fragment-bulk-sort", () => {
+  for (const count of fragmentCounts) {
+    const corpus = corpora.get(count);
+    if (corpus === undefined) continue;
+    const { canonical, scrambled } = corpus;
+    const label = count.toLocaleString();
+
+    // Each bench copies its input first, because sortFragments sorts in place
+    // and would otherwise measure an already-sorted array from iteration 2 on.
+    // The copy is an O(n) memcpy of object references — negligible next to the
+    // comparator work, but it is inside the timed region.
+
+    // Already in canonical order: the common case, and TimSort's best case
+    // since it detects the single ascending run.
+    bench(`sort ${label} frags (already sorted)`, () => {
+      const frags = [...canonical];
+      sortFragments(frags);
+      return frags;
+    });
+
+    // Fully scrambled: worst case, ~n log n comparator calls.
+    bench(`sort ${label} frags (shuffled)`, () => {
+      const frags = [...scrambled];
+      sortFragments(frags);
+      return frags;
+    });
+
+    // Target buffer for the rebuild benches, created outside the timed region.
+    // replaceFragments swaps in a fresh SumTree each call, so repeating it with
+    // the same fragments is idempotent.
+    const target = TextBuffer.create();
+
+    // Tree rebuild only: SumTree.fromItems + _fragmentIds index rebuild.
+    bench(`rebuild tree from ${label} frags`, () => {
+      target.replaceFragments(canonical);
+      return target;
+    });
+
+    // The full path TextBuffer takes after a split or remote insert:
+    // sortFragments + setFragments.
+    bench(`sort + rebuild ${label} frags (shuffled)`, () => {
+      const frags = [...scrambled];
+      sortFragments(frags);
+      target.replaceFragments(frags);
+      return target;
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -84,7 +84,7 @@ export {
 } from "./fragment.js";
 
 // TextBuffer
-export { TextBuffer } from "./text-buffer.js";
+export { TextBuffer, compareFragmentsForSort, sortFragments } from "./text-buffer.js";
 
 // Snapshot
 export { TextBufferSnapshot } from "./snapshot.js";

--- a/src/text/text-buffer.test.ts
+++ b/src/text/text-buffer.test.ts
@@ -17,7 +17,7 @@ import {
   locatorBetween,
   locatorsEqual,
 } from "./locator.js";
-import { TextBuffer } from "./text-buffer.js";
+import { TextBuffer, compareFragmentsForSort, sortFragments } from "./text-buffer.js";
 import { compareOperationIds, operationIdsEqual, replicaId } from "./types.js";
 import type { OperationId } from "./types.js";
 import { UndoMap } from "./undo-map.js";
@@ -1129,5 +1129,82 @@ describe("Remote delete with split fragments", () => {
     expect(buf1.getText()).toContain("X");
     expect(buf1.getText()).not.toContain("C");
     expect(buf1.getText()).not.toContain("D");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fragment list access and canonical sorting
+// ---------------------------------------------------------------------------
+
+describe("fragment list access", () => {
+  it("exposes fragments in canonical order", () => {
+    const buf = TextBuffer.create(replicaId(1));
+    buf.insert(0, "ABCDEF");
+    buf.insert(3, "X");
+
+    const frags = buf.fragmentList();
+    expect(frags.map((f) => f.text).join("")).toBe("ABCXDEF");
+
+    for (let i = 1; i < frags.length; i++) {
+      const prev = frags[i - 1];
+      const cur = frags[i];
+      if (prev === undefined || cur === undefined) continue;
+      expect(compareFragmentsForSort(prev, cur)).toBeLessThan(0);
+    }
+  });
+
+  it("returns a copy that does not alias buffer state", () => {
+    const buf = TextBuffer.create(replicaId(1));
+    buf.insert(0, "hello");
+
+    const frags = buf.fragmentList();
+    frags.length = 0;
+
+    expect(buf.getText()).toBe("hello");
+    expect(buf.fragmentList().length).toBeGreaterThan(0);
+  });
+
+  it("round-trips through sortFragments and replaceFragments", () => {
+    const buf = TextBuffer.create(replicaId(1));
+    buf.insert(0, "ABCDEF");
+    buf.insert(3, "X");
+    buf.delete(1, 2);
+
+    const expected = buf.getText();
+    const scrambled = buf.fragmentList().reverse();
+
+    sortFragments(scrambled);
+    buf.replaceFragments(scrambled);
+
+    expect(buf.getText()).toBe(expected);
+
+    // The rebuilt insertionId index still resolves, so further edits apply.
+    buf.insert(0, "Z");
+    expect(buf.getText()).toBe(`Z${expected}`);
+  });
+
+  it("sorts concurrent fragments with equal locators by operation ID", () => {
+    const rid1 = replicaId(1);
+    const rid2 = replicaId(2);
+
+    const buf1 = TextBuffer.create(rid1);
+    const buf2 = TextBuffer.create(rid2);
+
+    // Concurrent inserts into two empty buffers: same position, no shared history
+    const op1 = buf1.insert(0, "a");
+    const op2 = buf2.insert(0, "b");
+
+    buf1.applyRemote(op2);
+    buf2.applyRemote(op1);
+
+    expect(buf1.getText()).toBe(buf2.getText());
+
+    const frags = buf1.fragmentList();
+    for (let i = 1; i < frags.length; i++) {
+      const prev = frags[i - 1];
+      const cur = frags[i];
+      if (prev === undefined || cur === undefined) continue;
+      expect(compareFragmentsForSort(prev, cur)).toBeLessThan(0);
+    }
   });
 });

--- a/src/text/text-buffer.ts
+++ b/src/text/text-buffer.ts
@@ -88,8 +88,7 @@ function compareLocatorsForSort(a: Locator, b: Locator): number {
 }
 
 /**
- * Sort fragments to ensure canonical order regardless of operation application
- * sequence.
+ * Compare two fragments in canonical sort order.
  *
  * Sort key: (locator prefix, insertionId, insertionOffset, locator length)
  *
@@ -97,24 +96,32 @@ function compareLocatorsForSort(a: Locator, b: Locator): number {
  * 1. Fragments at the same position (locator prefix) sort by operation ID
  * 2. Split parts of the same operation sort by offset
  * 3. Child locators sort after parent locators with lower operation IDs
+ *
+ * Returns: <0 if a should come before b, >0 if after, 0 if equal.
  */
-function sortFragments(frags: Fragment[]): void {
-  frags.sort((a, b) => {
-    // First, compare by locator prefix
-    const locCmp = compareLocatorsForSort(a.locator, b.locator);
-    if (locCmp !== 0) return locCmp;
+export function compareFragmentsForSort(a: Fragment, b: Fragment): number {
+  // First, compare by locator prefix
+  const locCmp = compareLocatorsForSort(a.locator, b.locator);
+  if (locCmp !== 0) return locCmp;
 
-    // Same prefix: tie-break by operation ID
-    const idCmp = compareOperationIds(a.insertionId, b.insertionId);
-    if (idCmp !== 0) return idCmp;
+  // Same prefix: tie-break by operation ID
+  const idCmp = compareOperationIds(a.insertionId, b.insertionId);
+  if (idCmp !== 0) return idCmp;
 
-    // Same operation: sort by insertionOffset (split parts)
-    const offsetCmp = a.insertionOffset - b.insertionOffset;
-    if (offsetCmp !== 0) return offsetCmp;
+  // Same operation: sort by insertionOffset (split parts)
+  const offsetCmp = a.insertionOffset - b.insertionOffset;
+  if (offsetCmp !== 0) return offsetCmp;
 
-    // Finally, sort by locator length (children after parent)
-    return a.locator.levels.length - b.locator.levels.length;
-  });
+  // Finally, sort by locator length (children after parent)
+  return a.locator.levels.length - b.locator.levels.length;
+}
+
+/**
+ * Sort fragments in place to ensure canonical order regardless of operation
+ * application sequence.
+ */
+export function sortFragments(frags: Fragment[]): void {
+  frags.sort(compareFragmentsForSort);
 }
 
 // ---------------------------------------------------------------------------
@@ -580,6 +587,28 @@ export class TextBuffer {
    */
   get fragmentsRoot(): NodeId {
     return this.fragments.root;
+  }
+
+  /**
+   * Get a snapshot of the current fragment list, in canonical order.
+   *
+   * Returns a fresh array; mutating it does not affect the buffer. Useful for
+   * debugging, testing, and benchmarking the fragment sort/rebuild path.
+   */
+  fragmentList(): Fragment[] {
+    return this.fragmentsArray();
+  }
+
+  /**
+   * Replace the fragment tree with `frags`, rebuilding the SumTree and the
+   * insertionId index.
+   *
+   * Fragments must already be in canonical order (see {@link sortFragments});
+   * passing an unsorted array leaves the buffer in an inconsistent state.
+   * Useful for debugging, testing, and benchmarking the tree rebuild path.
+   */
+  replaceFragments(frags: Fragment[]): void {
+    this.setFragments(frags);
   }
 
   // ---------------------------------------------------------------------------
@@ -1510,7 +1539,7 @@ export class TextBuffer {
       }
 
       // Use same comparison as sortFragments for consistency
-      const cmp = this.compareFragmentsForSort(newFrag, frag);
+      const cmp = compareFragmentsForSort(newFrag, frag);
       if (cmp <= 0) {
         high = mid;
       } else {
@@ -1519,28 +1548,6 @@ export class TextBuffer {
     }
 
     frags.splice(low, 0, newFrag);
-  }
-
-  /**
-   * Compare two fragments using the same logic as sortFragments.
-   * This ensures insertFragmentByLocator produces the same order as sorting.
-   * Returns: <0 if a should come before b, >0 if after, 0 if equal.
-   */
-  private compareFragmentsForSort(a: Fragment, b: Fragment): number {
-    // First, compare by locator prefix (not lexicographic!)
-    const locCmp = compareLocatorsForSort(a.locator, b.locator);
-    if (locCmp !== 0) return locCmp;
-
-    // Same prefix: tie-break by operation ID
-    const idCmp = compareOperationIds(a.insertionId, b.insertionId);
-    if (idCmp !== 0) return idCmp;
-
-    // Same operation: sort by insertionOffset (split parts)
-    const offsetCmp = a.insertionOffset - b.insertionOffset;
-    if (offsetCmp !== 0) return offsetCmp;
-
-    // Finally, sort by locator length (children after parent)
-    return a.locator.levels.length - b.locator.levels.length;
   }
 
   /**
@@ -1565,7 +1572,7 @@ export class TextBuffer {
         continue;
       }
 
-      const cmp = this.compareFragmentsForSort(newFrag, frag);
+      const cmp = compareFragmentsForSort(newFrag, frag);
       if (cmp <= 0) {
         high = mid;
       } else {


### PR DESCRIPTION
Closes #187.

Adds a `fragment-bulk-sort` group to `benchmarks/text-buffer.ts` establishing the JS baseline that any alternative sorting strategy (#117) would need to beat.

## What's measured

Four benches per fragment count, isolating the three costs `TextBuffer` pays whenever a split or remote insert forces a canonical re-order:

| bench | what it covers |
|---|---|
| `sort N frags (already sorted)` | `Array.sort` on canonical input — the common case, and TimSort's best case |
| `sort N frags (shuffled)` | `Array.sort` worst case, ~n log n comparator calls |
| `rebuild tree from N frags` | `setFragments` only: `SumTree.fromItems` **and** the `_fragmentIds` index rebuild |
| `sort + rebuild N frags (shuffled)` | the full `sortFragments()` + `setFragments()` path |

## Baseline

bun 1.3.14, arm64-linux @ ~3 GHz, avg/iter:

| frags | sort (sorted) | sort (shuffled) | rebuild only | sort + rebuild |
|------:|--------------:|----------------:|-------------:|---------------:|
|  1K   |     37.5 µs   |         315 µs  |      120 µs  |        462 µs  |
| 10K   |     1.10 ms   |        7.94 ms  |     3.39 ms  |       12.2 ms  |
| 50K   |     18.8 ms   |         111 ms  |     45.2 ms  |        156 ms  |

Headline for #117: sorting 10K fragments from scratch costs ~8 ms, and the tree rebuild adds ~3 ms on top. The table is also recorded as a comment in the benchmark file so the baseline stays easy to find.

## Corpus generation

The comparator walks locator levels, so its cost scales with locator *depth*, not just fragment count — a synthetic fragment array gets this wrong (~3.5 levels avg vs ~12 for real editing, understating sort cost by ~2x). So corpora are built by real editing: four peers each perform single-char inserts at random offsets (one fragment per insert) and their fragments are merged in canonical order. This models peers editing offline and then syncing, which is where a full bulk sort actually happens, and it produces representative locator depth (~6 levels at 1K, ~12 at 50K) plus real operation-ID ties (~25% of adjacent pairs share a locator).

Building peers separately also keeps setup affordable — local inserts get more expensive as a buffer grows, so 4 buffers of n/4 cost far less than one of n. Total corpus setup is ~17 s, all of it outside the timed regions.

## API changes

The benchmark needs the sort internals, which were unexported/private:

- `sortFragments` is now exported, along with a new module-level `compareFragmentsForSort`. The private `TextBuffer.compareFragmentsForSort` method was a verbatim duplicate of the comparator inlined in `sortFragments` — both now share the one function, so the two orderings can no longer drift apart.
- `TextBuffer.fragmentList()` and `TextBuffer.replaceFragments()` are documented debugging/benchmarking accessors over the private `fragmentsArray`/`setFragments`, following the existing `fragmentsRoot` precedent.

Four tests cover the newly public surface: canonical ordering of `fragmentList()`, that it returns a non-aliasing copy, a `sortFragments` → `replaceFragments` round trip that leaves the buffer editable, and equal-locator concurrent fragments ordered by operation ID.

## Notes

- `benchmarks/text-buffer.ts` is not run in CI (`bench:record` only runs `bench:compare:ci`), so the ~17 s setup and the 10% regression threshold on other groups are both unaffected.
- Each sort bench copies its input inside the timed region, since `sortFragments` sorts in place and would otherwise measure an already-sorted array from iteration 2 on. The copy is an O(n) memcpy of references — negligible next to the comparator work, and noted in the file.

`bun test` 3970 pass / 0 fail; `bun run typecheck` clean; lint clean except two pre-existing errors in the untouched `scripts/record-benchmarks.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)