### PR TITLE
fix: add release guard to lines() and chunks() on TextBufferSnapshot

### DIFF
--- a/src/text/snapshot.test.ts
+++ b/src/text/snapshot.test.ts
@@ -115,6 +115,27 @@ describe("TextBufferSnapshot", () => {
       expect(() => snapshot.lineCount).toThrow("Cannot use released snapshot");
     });
 
+    test("lines() and chunks() work before release", () => {
+      const buffer = TextBuffer.fromString("alpha\nbeta");
+      const snapshot = buffer.snapshot();
+
+      expect([...snapshot.lines()]).toEqual(["alpha", "beta"]);
+      expect([...snapshot.chunks()].join("")).toBe("alpha\nbeta");
+
+      snapshot.release();
+    });
+
+    test("release() prevents iteration via lines() and chunks()", () => {
+      const buffer = TextBuffer.fromString("alpha\nbeta");
+      const snapshot = buffer.snapshot();
+
+      snapshot.release();
+
+      // Iterators must honour the same release guard as the other read paths
+      expect(() => [...snapshot.lines()]).toThrow("Cannot use released snapshot");
+      expect(() => [...snapshot.chunks()]).toThrow("Cannot use released snapshot");
+    });
+
     test("release() is idempotent", () => {
       const buffer = TextBuffer.fromString("test");
       const snapshot = buffer.snapshot();

--- a/src/text/snapshot.ts
+++ b/src/text/snapshot.ts
@@ -406,6 +406,7 @@ export class TextBufferSnapshot implements DocumentSnapshot {
    * ```
    */
   *lines(startLine?: number, endLine?: number): IterableIterator<string> {
+    this.checkReleased();
     yield* this.getRope().lines(startLine, endLine);
   }
 
@@ -426,6 +427,7 @@ export class TextBufferSnapshot implements DocumentSnapshot {
    * ```
    */
   *chunks(start?: number, end?: number): IterableIterator<string> {
+    this.checkReleased();
     yield* this.getRope().chunks(start, end);
   }
 


### PR DESCRIPTION
Fixes #349.

## What

`TextBufferSnapshot.lines()` and `.chunks()` were the only two of its public read paths that skipped the private `checkReleased()` guard — they went straight to `this.getRope()`. A released snapshot therefore kept serving text through those two methods while `getText()`, `getLine()`, `length`, `lineCount` and the rest all threw `Cannot use released snapshot`.

Two-line fix, matching the guard style used everywhere else in the class:

```ts
*lines(startLine?: number, endLine?: number): IterableIterator<string> {
  this.checkReleased();
  yield* this.getRope().lines(startLine, endLine);
}
```

## Tests

Two tests added to the existing `release() lifecycle` block:

- `release() prevents iteration via lines() and chunks()` — the regression test from the issue. Fails without the fix (24 pass / 1 fail), passes with it.
- `lines() and chunks() work before release` — these methods had **no** test coverage at all before (`snapshot.ts` uncovered span `383-428` was exactly these two). Without a happy-path assertion, a guard that always threw would look just as green. Cheap insurance, and it closes the coverage hole the issue identified.

## Notes for the reviewer

**Generator laziness — deliberate.** Both methods are generators, so the guard runs on the first `next()`, not at call time. `snap.lines()` alone doesn't throw; `for...of` / spread / `Array.from` all do. That covers every realistic consumption pattern. Eager rejection would mean converting both to non-generator functions returning an inner iterator; not worth the extra surface for a debug-assist guard. This matches the tradeoff accepted in #351.

**Severity, stated accurately.** This is a guard gap and a stale read, *not* demonstrated memory corruption. The reporter tried to escalate it to a use-after-free read and could not — `collectGarbage()` freed 0 nodes and the post-GC read was byte-identical. Nothing here should be read as fixing a demonstrated corruption bug.

**Relationship to #351.** #351 has the same core two-line fix and is mergeable and approved by comment. Either can land — merge one and close the other. This branch additionally carries the happy-path coverage. Worth noting for the record: #351 has **no** changes-requested review (`reviews: []`, `reviewDecision: ""`); its only comment is an approval. The red `Check` on it is #346 — `bun run lint` fails on `scripts/record-benchmarks.ts` on pristine `HEAD`, unrelated to either PR.

**#346 will block this PR too.** Because `Lint` gates `Test` in CI, this PR's `Check` will fail for the same unrelated reason and no tests will run in CI. I kept this PR scoped to the fix rather than folding in a `lint:fix` for the benchmark script. Local verification below.

## Verification

| Check | Result |
|---|---|
| `bun test src/text/snapshot.test.ts` | 25 pass / 0 fail |
| same, with the fix reverted | 24 pass / 1 fail (the new regression test) |
| `bun test` (full suite) | 3,968 pass / 0 fail |
| `bun run typecheck` | clean |
| `biome check` on the two changed files | clean |

## Optional follow-up (not in this PR)

The guard is a convention every new read method has to remember, and this bug is proof the convention doesn't hold on its own. Moving `this.checkReleased()` into the private `getRope()` would make it structural for all rope-backed reads. It wouldn't cover the tree-backed paths (`seekToInsertion`, anchors, `visitFragments`), which still need explicit guards. Happy to open that as a separate issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)